### PR TITLE
Support integer, atom or strings as aggregate_uuid in Commanded.Aggregates.Registry.open_aggregate(aggregate_module, aggregate_uuid)

### DIFF
--- a/lib/commanded/aggregates/registry.ex
+++ b/lib/commanded/aggregates/registry.ex
@@ -15,8 +15,11 @@ defmodule Commanded.Aggregates.Registry do
     GenServer.start_link(__MODULE__, %Registry{}, name: __MODULE__)
   end
 
-  def open_aggregate(aggregate_module, aggregate_uuid) do
-    GenServer.call(__MODULE__, {:open_aggregate, aggregate_module, aggregate_uuid})
+  def open_aggregate(aggregate_module, aggregate_uuid)
+  when is_integer(aggregate_uuid) or
+       is_atom(aggregate_uuid) or
+       is_bitstring(aggregate_uuid) do
+    GenServer.call(__MODULE__, {:open_aggregate, aggregate_module, to_string(aggregate_uuid)})
   end
 
   def init(%Registry{} = state) do

--- a/lib/commanded/event/handler.ex
+++ b/lib/commanded/event/handler.ex
@@ -3,7 +3,6 @@ defmodule Commanded.Event.Handler do
   require Logger
 
   alias Commanded.Event.Handler
-  alias Commanded.Event.Serializer
 
   defstruct handler_name: nil, handler_module: nil, last_seen_event_id: nil
 
@@ -40,7 +39,7 @@ defmodule Commanded.Event.Handler do
     Logger.debug(fn -> "event handler has already seen event: #{inspect event}" end)
   end
 
-  defp handle_event(%EventStore.RecordedEvent{data: data} = event, %Handler{handler_module: handler_module}) do
+  defp handle_event(%EventStore.RecordedEvent{data: data}, %Handler{handler_module: handler_module}) do
     data
     |> handler_module.handle
   end

--- a/test/aggregates/registry_test.exs
+++ b/test/aggregates/registry_test.exs
@@ -1,0 +1,17 @@
+defmodule RegistryTest do
+  use ExUnit.Case
+
+  alias Commanded.Aggregates.Registry
+
+  setup do
+    EventStore.Storage.reset!
+    Commanded.Supervisor.start_link
+    :ok
+  end
+
+  test "should let use integer, atom or string as aggregate_uuid" do
+    Enum.each([1, :atom, "string"], fn aggregate_uuid ->
+      {:ok, _aggregate} = Registry.open_aggregate(BankAccount, aggregate_uuid)
+    end)
+  end
+end


### PR DESCRIPTION
lets integer, atom or strings as aggregate_uuid in 
```
Commanded.Aggregates.Registry.open_aggregate(aggregate_module, aggregate_uuid)
```

using other values than string raising low level error on postgrex driver about text type