### PR TITLE
Don't persist an aggregate's pending events when executing a command returns an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,4 +287,5 @@ You should include unit tests to cover any changes. Run `mix test` to execute th
 
 ### Contributors
 
+- [Andrey Akulov](https://github.com/astery)
 - [Andrzej Sliwa](https://github.com/andrzejsliwa)

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -5,7 +5,7 @@ defmodule Commanded.Commands.Dispatcher do
 
   # @spec dispatch(struct) :: :ok
   def dispatch(command, handler_module, aggregate_module, identity) do
-    Logger.debug(fn -> "attempting to dispatch command: #{inspect command}, to: #{handler_module}, aggregate: #{aggregate_module}" end)
+    Logger.debug(fn -> "attempting to dispatch command: #{inspect command}, to: #{inspect handler_module}, aggregate: #{inspect aggregate_module}, identity: #{inspect identity}" end)
 
     aggregate_uuid = Map.get(command, identity)
 

--- a/lib/commanded/commands/handler.ex
+++ b/lib/commanded/commands/handler.ex
@@ -1,10 +1,15 @@
 defmodule Commanded.Commands.Handler do
+
+  @type aggregate_root :: struct()
+  @type command :: struct()
+  @type reason :: term()
+
   @doc """
   Apply the given command to the event-sourced aggregate root.
 
-  You must return the updated aggregate root on success. This is the struct containing the aggregate's id, pending events and current version.
+  You must return `{:ok, aggregate}` with the updated aggregate root on success. This is the struct containing the aggregate's uuid, pending events, and current version.
 
   You should return `{:error, reason}` on failure.
   """
-  @callback handle(EventSourced.AggregateRoot, command :: %{}) :: EventSourced.AggregateRoot | {:error, reason :: term}
+  @callback handle(aggregate_root, command) :: {:ok, aggregate_root} | {:error, reason}
 end

--- a/lib/commanded/commands/handler.ex
+++ b/lib/commanded/commands/handler.ex
@@ -1,6 +1,10 @@
 defmodule Commanded.Commands.Handler do
   @doc """
-  Apply the given command to the event sourced entity state, returning state struct containing the entity's id, all applied events and current version
+  Apply the given command to the event-sourced aggregate root.
+
+  You must return the updated aggregate root on success. This is the struct containing the aggregate's id, pending events and current version.
+
+  You should return `{:error, reason}` on failure.
   """
-  @callback handle(state :: EventSourced.Entity, command :: %{}) :: EventSourced.Entity
+  @callback handle(EventSourced.AggregateRoot, command :: %{}) :: EventSourced.AggregateRoot | {:error, reason :: term}
 end

--- a/mix.exs
+++ b/mix.exs
@@ -30,12 +30,12 @@ defmodule Commanded.Mixfile do
 
   defp deps do
     [
-      {:eventstore, "~> 0.4.1"},
-      {:eventsourced, "~> 0.1.0"},
-      {:ex_doc, "~> 0.13.0", only: :dev},
+      {:eventstore, "~> 0.4"},
+      {:eventsourced, "~> 0.1"},
+      {:ex_doc, "~> 0.13", only: :dev},
       {:markdown, github: "devinus/markdown", only: :dev},
       {:mix_test_watch, "~> 0.2", only: :dev},
-      {:poison, "~> 2.2.0"},
+      {:poison, "~> 2.2"},
       {:uuid, "~> 1.1"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "decimal": {:hex, :decimal, "1.1.2", "79a769d4657b2d537b51ef3c02d29ab7141d2b486b516c109642d453ee08e00c", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.1", "2c2cd903bfdc3de3f189bd9a8d4569a075b88a8981ded9a0d95672f6e2b63141", [:mix], []},
   "eventsourced": {:hex, :eventsourced, "0.1.0", "7c92e31abf5874f8a81bf6081febbfbc972e940f75d02163bbcdfaa9edbfb964", [:mix], []},
-  "eventstore": {:hex, :eventstore, "0.4.1", "722d557dd074e7a7bcc286a08730423af50c7ff6bee31c7648479e5afbe15cbc", [:mix], [{:fsm, "~> 0.2.0", [hex: :fsm, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.11.1", [hex: :postgrex, optional: false]}]},
+  "eventstore": {:hex, :eventstore, "0.4.3", "6da667f5186b39b084f1227aee18478de55d91f6026bec2bffabef5495f3b37a", [:mix], [{:fsm, "~> 0.2", [hex: :fsm, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.12", [hex: :postgrex, optional: false]}]},
   "ex_doc": {:hex, :ex_doc, "0.13.2", "1059a588d2ad3ffab25a0b85c58abf08e437d3e7a9124ac255e1d15cec68ab79", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "fsm": {:hex, :fsm, "0.2.0", "53bcc0fd4a470c92cbbc3bae2d7f7dd8462898eedd62c37a6be556b94fba0e05", [:mix], []},
@@ -12,5 +12,5 @@
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "poison": {:hex, :poison, "2.2.0", "4763b69a8a77bd77d26f477d196428b741261a761257ff1cf92753a0d4d24a63", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
-  "postgrex": {:hex, :postgrex, "0.11.2", "139755c1359d3c5c6d6e8b1ea72556d39e2746f61c6ddfb442813c91f53487e8", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
+  "postgrex": {:hex, :postgrex, "0.12.0", "bdeeb4c42768c47c3c92228e66c70357fe9a9384fbc9de06abba774b22dd0635", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc.4", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [:mix], []}}

--- a/test/aggregates/execute_command_for_aggregate_test.exs
+++ b/test/aggregates/execute_command_for_aggregate_test.exs
@@ -14,7 +14,7 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
     :ok
   end
 
-  test "should execute command against an aggregate" do
+  test "execute command against an aggregate" do
     account_number = UUID.uuid4
 
     {:ok, aggregate} = Registry.open_aggregate(BankAccount, account_number)
@@ -35,29 +35,6 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
     assert bank_account.version == 1
   end
 
-  test "should execute command against an aggregate with concurrency error should reload events and retry command" do
-    account_number = UUID.uuid4
-
-    {:ok, aggregate} = Registry.open_aggregate(BankAccount, account_number)
-
-    {:ok, stream} = EventStore.Streams.open_stream(account_number)
-
-    # write an event to the aggregate's stream, bypassing the aggregate process (simulate concurrency error)
-    EventStore.Streams.Stream.append_to_stream(stream, 0, [
-      %EventStore.EventData{
-        event_type: "Elixir.Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened",
-        data: %BankAccountOpened{account_number: account_number, initial_balance: 1_000}
-      }
-    ])
-
-    Aggregate.execute(aggregate, %DepositMoney{account_number: account_number, transfer_uuid: UUID.uuid4, amount: 50}, DepositMoneyHandler)
-
-    bank_account = Aggregate.aggregate_state(aggregate)
-
-    assert bank_account.state.account_number == account_number
-    assert bank_account.state.balance == 1_050
-  end
-
   test "aggregate returning an error tuple should not persist pending events or state" do
     account_number = UUID.uuid4
 
@@ -70,9 +47,35 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
     # attempt to open same account should fail with a descriptive error
     {:error, :account_already_open} = Aggregate.execute(aggregate, %OpenAccount{account_number: account_number, initial_balance: 1}, OpenAccountHandler)
 
-    state_after = Aggregate.aggregate_state(aggregate)
+    assert state_before == Aggregate.aggregate_state(aggregate)
+  end
 
-    assert state_before == state_after
+  test "executing a command against an aggregate with concurrency error should terminate aggregate process" do
+    account_number = UUID.uuid4
+
+    {:ok, aggregate} = Registry.open_aggregate(BankAccount, account_number)
+    {:ok, stream} = EventStore.Streams.open_stream(account_number)
+
+    # block until aggregate has loaded its initial (empty) state
+    Aggregate.aggregate_state(aggregate)
+
+    # write an event to the aggregate's stream, bypassing the aggregate process (simulate concurrency error)
+    :ok = EventStore.Streams.Stream.append_to_stream(stream, 0, [
+      %EventStore.EventData{
+        event_type: "Elixir.Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened",
+        data: %BankAccountOpened{account_number: account_number, initial_balance: 1_000}
+      }
+    ])
+
+    Process.flag(:trap_exit, true)
+
+    spawn_link(fn ->
+      Aggregate.execute(aggregate, %DepositMoney{account_number: account_number, transfer_uuid: UUID.uuid4, amount: 50}, DepositMoneyHandler)
+    end)
+
+    # aggregate process should crash
+    assert_receive({:EXIT, _from, _reason})
+    assert Process.alive?(aggregate) == false
   end
 
   @tag :skip

--- a/test/commands/handle_command_test.exs
+++ b/test/commands/handle_command_test.exs
@@ -6,7 +6,7 @@ defmodule Commanded.Commands.HandleCommandTest do
   alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
 
   test "command handler implements behaviour" do
-    bank_account =
+    {:ok, bank_account} =
       BankAccount.new("1")
       |> OpenAccountHandler.handle(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
 

--- a/test/example_domain/bank_account/bank_account.ex
+++ b/test/example_domain/bank_account/bank_account.ex
@@ -39,22 +39,31 @@ defmodule Commanded.ExampleDomain.BankAccount do
   end
 
   def open_account(%BankAccount{state: %{is_active?: false}} = account, %OpenAccount{account_number: account_number, initial_balance: initial_balance}) when is_number(initial_balance) and initial_balance > 0 do
-    account
-    |> update(%BankAccountOpened{account_number: account_number, initial_balance: initial_balance})
+    account =
+      account
+      |> update(%BankAccountOpened{account_number: account_number, initial_balance: initial_balance})
+
+    {:ok, account}
   end
 
   def deposit(%BankAccount{} = account, %DepositMoney{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount}) when is_number(amount) and amount > 0 do
     balance = account.state.balance + amount
 
-    account
-    |> update(%MoneyDeposited{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance})
+    account =
+      account
+      |> update(%MoneyDeposited{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance})
+
+    {:ok, account}
   end
 
   def withdraw(%BankAccount{} = account, %WithdrawMoney{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount}) when is_number(amount) and amount > 0 do
     balance = account.state.balance - amount
 
-    account
-    |> update(%MoneyWithdrawn{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance})
+    account =
+      account
+      |> update(%MoneyWithdrawn{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance})
+
+    {:ok, account}
   end
 
   # state mutatators

--- a/test/example_domain/money_transfer/money_transfer.ex
+++ b/test/example_domain/money_transfer/money_transfer.ex
@@ -19,8 +19,11 @@ defmodule Commanded.ExampleDomain.MoneyTransfer do
   alias Events.{MoneyTransferRequested}
 
   def transfer_money(%MoneyTransfer{} = money_transfer, %TransferMoney{transfer_uuid: transfer_uuid, source_account: source_account, target_account: target_account, amount: amount}) when amount > 0 do
-    money_transfer
-    |> update(%MoneyTransferRequested{transfer_uuid: transfer_uuid, source_account: source_account, target_account: target_account, amount: amount})
+    money_transfer =
+      money_transfer
+      |> update(%MoneyTransferRequested{transfer_uuid: transfer_uuid, source_account: source_account, target_account: target_account, amount: amount})
+
+    {:ok, money_transfer}
   end
 
   # state mutatators

--- a/test/example_domain/money_transfer/transfer_money_process_manager.ex
+++ b/test/example_domain/money_transfer/transfer_money_process_manager.ex
@@ -20,12 +20,14 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
       transfer
       |> dispatch(%WithdrawMoney{account_number: source_account, transfer_uuid: transfer_uuid, amount: amount})
 
-    %TransferMoneyProcessManager{transfer |
+    transfer = %TransferMoneyProcessManager{transfer |
       source_account: source_account,
       target_account: target_account,
       amount: amount,
       status: :withdraw_money_from_source_account
     }
+
+    {:ok, transfer}
   end
 
   def handle(%TransferMoneyProcessManager{transfer_uuid: transfer_uuid} = transfer, %MoneyWithdrawn{} = _money_withdrawn) do
@@ -33,19 +35,24 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
       transfer
       |> dispatch(%DepositMoney{account_number: transfer.target_account, transfer_uuid: transfer_uuid, amount: transfer.amount})
 
-    %TransferMoneyProcessManager{transfer |
+    transfer = %TransferMoneyProcessManager{transfer |
       status: :deposit_money_in_target_account
     }
+
+    {:ok, transfer}
   end
 
   def handle(%TransferMoneyProcessManager{} = transfer, %MoneyDeposited{} = _money_deposited) do
-    %TransferMoneyProcessManager{transfer |
+    transfer = %TransferMoneyProcessManager{transfer |
       status: :transfer_complete
     }
+
+    {:ok, transfer}
   end
 
-  def handle(_transfer, _event) do
-      # ignore any other events
+  def handle(transfer, _event) do
+    # ignore any other events
+    {:ok, transfer}
   end
 
   defp dispatch(%TransferMoneyProcessManager{commands: commands} = transfer, command) do

--- a/test/process_managers/process_manager_test.exs
+++ b/test/process_managers/process_manager_test.exs
@@ -15,6 +15,8 @@ defmodule Commanded.ProcessManager.ProcessManagerTest do
   end
 
   defmodule OpenAccountHandler do
+    @behaviour Commanded.Commands.Handler
+
     def handle(%BankAccount{} = aggregate, %WithdrawMoney{}) do
       aggregate
     end

--- a/test/process_managers/process_manager_test.exs
+++ b/test/process_managers/process_manager_test.exs
@@ -18,7 +18,7 @@ defmodule Commanded.ProcessManager.ProcessManagerTest do
     @behaviour Commanded.Commands.Handler
 
     def handle(%BankAccount{} = aggregate, %WithdrawMoney{}) do
-      aggregate
+      {:ok, aggregate}
     end
   end
 

--- a/test/process_managers/resume_process_manager_test.exs
+++ b/test/process_managers/resume_process_manager_test.exs
@@ -40,13 +40,19 @@ defmodule Commanded.ProcessManager.ResumeProcessManagerTest do
     alias Events.{ProcessStarted,ProcessResumed}
 
     def start_process(%ExampleAggregate{} = aggregate, %StartProcess{process_uuid: process_uuid, status: status}) do
-      aggregate
-      |> update(%ProcessStarted{process_uuid: process_uuid, status: status})
+      aggregate =
+        aggregate
+        |> update(%ProcessStarted{process_uuid: process_uuid, status: status})
+
+      {:ok, aggregate}
     end
 
     def resume_process(%ExampleAggregate{} = aggregate, %ResumeProcess{process_uuid: process_uuid, status: status}) do
-      aggregate
-      |> update(%ProcessResumed{process_uuid: process_uuid, status: status})
+      aggregate =
+        aggregate
+        |> update(%ProcessResumed{process_uuid: process_uuid, status: status})
+
+      {:ok, aggregate}
     end
 
     # state mutatators
@@ -102,20 +108,25 @@ defmodule Commanded.ProcessManager.ResumeProcessManagerTest do
     end
 
     def handle(%ExampleProcessManager{status_history: status_history} = process, %ProcessStarted{process_uuid: process_uuid, status: status}) do
-      %ExampleProcessManager{process |
+      process = %ExampleProcessManager{process |
         process_uuid: process_uuid,
         status_history: [status | status_history]
       }
+
+      {:ok, process}
     end
 
     def handle(%ExampleProcessManager{status_history: status_history} = process, %ProcessResumed{status: status}) do
-      %ExampleProcessManager{process |
+      process = %ExampleProcessManager{process |
         status_history: [status | status_history]
       }
+
+      {:ok, process}
     end
 
-    def handle(_transfer, _event) do
-        # ignore any other events
+    def handle(process, _event) do
+      # ignore any other events
+      {:ok, process}
     end
   end
 


### PR DESCRIPTION
Don't persist an aggregate's pending events when executing a command returns an error.

An Aggregate should enforce domain rules by returning an error tuple instead of its state on failure. 

- An aggregate function must return `{:ok, aggregate}` on success.
- An aggregate function should return `{:error, reason}` on failure.

The example bank account aggregate returns `{:error, :account_already_open}` should an attempt be made to open an existing account.

```elixir
defmodule Commanded.ExampleDomain.BankAccount do
  def open_account(%BankAccount{state: %{is_active?: true}} = account, %OpenAccount{}) do
    {:error, :account_already_open}
  end

  def open_account(%BankAccount{state: %{is_active?: false}} = account, %OpenAccount{account_number: account_number, initial_balance: initial_balance}) when is_number(initial_balance) and initial_balance > 0 do
    account = 
      account
      |> update(%BankAccountOpened{account_number: account_number, initial_balance: initial_balance})

    {:ok, account}
  end
end
```

The error will be returned to the caller when the command is dispatched.

```elixir
# open account should initially succeed
:ok = Router.dispatch(%OpenAccount{account_number: "acc1"})

# attempting to open same account should error
{:error, :account_already_open} = Router.dispatch(%OpenAccount{account_number: "acc1"})
```

Fixes #9.