### PR TITLE
Fix pending aggregates restarts: Supervisor restarts aggregate, that loses command routing and remains pending

### DIFF
--- a/lib/commanded/aggregates/supervisor.ex
+++ b/lib/commanded/aggregates/supervisor.ex
@@ -18,7 +18,7 @@ defmodule Commanded.Aggregates.Supervisor do
 
   def init(_) do
     children = [
-      worker(Commanded.Aggregates.Aggregate, [], restart: :transient),
+      worker(Commanded.Aggregates.Aggregate, [], restart: :temporary),
     ]
 
     supervise(children, strategy: :simple_one_for_one)


### PR DESCRIPTION
When we start a new aggregate, and kill it, supervisor immediately restart it with the last state, replaying all the events. But when sending a new Command to the same aggregate UUID, a new aggregate is created, and updated, so we end up with two aggregates on memory, one unusable (and consumed resources to be restarted) and a new fresh one, that was started by the last command request. Using :observer.start can help to track their state and see what is going on. Pls, let me know if you need more details to reproduce it.