### PR TITLE
Command handling middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.0
+
+### Enhancements
+
+- Command handling middleware allows a command router to define middleware modules that are executed before, and after success or failure of each command dispatch ([#12](https://github.com/slashdotdash/commanded/issues/12)).
+
 ## v0.6.3
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -197,19 +197,24 @@ Implement the `Commanded.Middleware` behaviour in your module and define the `be
 defmodule NoOpMiddleware do
   @behaviour Commanded.Middleware
 
-  def before_dispatch(%{command: command} = pipeline) do
+  alias Commanded.Middleware.Pipeline
+  import Pipeline
+
+  def before_dispatch(%Pipeline{command: command} = pipeline) do
     pipeline
   end
 
-  def after_dispatch(%{command: command} = pipeline) do
+  def after_dispatch(%Pipeline{} = pipeline) do
     pipeline
   end
 
-  def after_failure(%{command: command} = pipeline) do
+  def after_failure(%Pipeline{} = pipeline) do
     pipeline
   end
 end
 ```
+
+Commanded provides a `Commanded.Middleware.Logger` middleware for logging the name of each dispatched command and its execution duration.
 
 ### Event handlers
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
 
     ```elixir
     def deps do
-      [{:commanded, "~> 0.6"}]
+      [{:commanded, "~> 0.7"}]
     end
     ```
 
@@ -165,6 +165,49 @@ defmodule BankRouter do
   use Commanded.Commands.Router
 
   dispatch [OpenAccount,CloseAccount], to: BankAccountHandler, aggregate: BankAccount, identity: :account_number
+end
+```
+
+### Middleware
+
+Allows a command router to define middleware modules that are executed before and after success or failure of each command dispatch.
+
+This provides an extension point to add in command validation, authorization, logging, and other behaviour that you want to be called for every command the router dispatches.
+
+```elixir
+defmodule BankingRouter do
+  use Commanded.Commands.Router
+
+  middleware CommandLogger
+  middleware MyCommandValidator
+  middleware AuthorizeCommand
+
+  dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
+  dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount, identity: :account_number
+end
+```
+
+The middleware modules are executed in the order they’ve been defined. They will receive a `Commanded.Middleware.Pipeline` struct containing the command being dispatched.
+
+#### Example middleware
+
+Implement the `Commanded.Middleware` behaviour in your module and define the `before_dispatch`, `after_dispatch`, and `after_failure` callback functions.
+
+```elixir
+defmodule NoOpMiddleware do
+  @behaviour Commanded.Middleware
+
+  def before_dispatch(%{command: command} = pipeline) do
+    pipeline
+  end
+
+  def after_dispatch(%{command: command} = pipeline) do
+    pipeline
+  end
+
+  def after_failure(%{command: command} = pipeline) do
+    pipeline
+  end
 end
 ```
 

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -30,6 +30,8 @@ defmodule Commanded.Aggregates.Aggregate do
   Execute the given command against the aggregate, optionally providing a timeout.
   - `timeout` is an integer greater than zero which specifies how many milliseconds to wait for a reply, or the atom :infinity to wait indefinitely.
     The default value is 5000.
+
+  Returns `:ok` on success, or `{:error, reason}` on failure
   """
   def execute(server, command, handler, timeout \\ 5_000) do
     GenServer.call(server, {:execute_command, command, handler}, timeout)

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -2,24 +2,66 @@ defmodule Commanded.Commands.Dispatcher do
   require Logger
 
   alias Commanded.Aggregates
+  alias Commanded.Middleware.Pipeline
+
+  defmodule Context do
+    defstruct [
+      command: nil,
+      handler_module: nil,
+      aggregate_module: nil,
+      identity: nil,
+      timeout: nil,
+      middleware: [],
+    ]
+  end
 
   @doc """
   Dispatch the given command to the handler module for the aggregate root as identified
   Returns `:ok` on success.
   """
-  @spec dispatch(command :: struct, handler_module :: atom, aggregate_module :: atom, identity :: atom, timeout :: integer | :infinity) :: :ok | {:error, reason :: term}
-  def dispatch(command, handler_module, aggregate_module, identity, timeout) do
-    Logger.debug(fn -> "attempting to dispatch command: #{inspect command}, to: #{inspect handler_module}, aggregate: #{inspect aggregate_module}, identity: #{inspect identity}" end)
+  @spec dispatch(context :: struct) :: :ok | {:error, reason :: term}
+  def dispatch(%Context{command: command, identity: identity} = context) do
+    Logger.debug(fn -> "attempting to dispatch command: #{inspect command}, to: #{inspect context.handler_module}, aggregate: #{inspect context.aggregate_module}, identity: #{inspect identity}" end)
 
     case Map.get(command, identity) do
       nil -> {:error, :invalid_aggregate_identity}
-      aggregate_uuid -> execute(command, handler_module, aggregate_module, aggregate_uuid, timeout)
+      aggregate_uuid -> execute(context, aggregate_uuid)
     end
   end
 
-  defp execute(command, handler_module, aggregate_module, aggregate_uuid, timeout) do
+  defp execute(%Context{command: command, aggregate_module: aggregate_module, handler_module: handler_module, timeout: timeout, middleware: middleware}, aggregate_uuid) do
+    pipeline =
+      %Pipeline{
+        command: command,
+        timeout: timeout,
+      }
+      |> before_dispatch(middleware)
+
     {:ok, aggregate} = Aggregates.Registry.open_aggregate(aggregate_module, aggregate_uuid)
 
-    Aggregates.Aggregate.execute(aggregate, command, handler_module, timeout)
+    reply = Aggregates.Aggregate.execute(aggregate, command, handler_module, timeout)
+
+    case reply do
+      :ok -> after_dispatch(pipeline, middleware)
+      {:error, error} -> after_failure(pipeline, error, middleware)
+    end
+
+    reply
+  end
+
+  def before_dispatch(%Pipeline{} = pipeline, middleware) do
+    pipeline
+    |> Pipeline.chain(:before_dispatch, middleware)
+  end
+
+  def after_dispatch(%Pipeline{} = pipeline, middleware) do
+    pipeline
+    |> Pipeline.chain(:after_dispatch, middleware)
+  end
+
+  def after_failure(%Pipeline{} = pipeline, error, middleware) do
+    pipeline
+    |> Pipeline.assign(:error, error)
+    |> Pipeline.chain(:after_failure, middleware)
   end
 end

--- a/lib/commanded/commands/handler.ex
+++ b/lib/commanded/commands/handler.ex
@@ -1,5 +1,4 @@
 defmodule Commanded.Commands.Handler do
-
   @type aggregate_root :: struct()
   @type command :: struct()
   @type reason :: term()

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -10,7 +10,9 @@ defmodule Commanded.Commands.Router do
   end
 
   @doc """
-  Include the given middleware module to be called before, after, and failure of each command dispatch
+  Include the given middleware module to be called before and after success or failure of each command dispatch
+
+  Middleware modules are executed in the order they’ve been defined.
   """
   defmacro middleware(middleware_module) do
     quote do

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -53,7 +53,7 @@ defmodule Commanded.Commands.Router do
       @spec dispatch(command :: struct) :: :ok | {:error, reason :: term}
       def dispatch(command)
       def dispatch(%unquote(command_module){} = command) do
-        Commanded.Commands.Dispatcher.dispatch(%Commanded.Commands.Dispatcher.Context{
+        Commanded.Commands.Dispatcher.dispatch(%Commanded.Commands.Dispatcher.Payload{
           command: command,
           handler_module: unquote(handler),
           aggregate_module: unquote(aggregate),
@@ -74,7 +74,7 @@ defmodule Commanded.Commands.Router do
       @spec dispatch(command :: struct, timeout :: integer | :infinity) :: :ok | {:error, reason :: term}
       def dispatch(command, timeout)
       def dispatch(%unquote(command_module){} = command, timeout) do
-        Commanded.Commands.Dispatcher.dispatch(%Commanded.Commands.Dispatcher.Context{
+        Commanded.Commands.Dispatcher.dispatch(%Commanded.Commands.Dispatcher.Payload{
           command: command,
           handler_module: unquote(handler),
           aggregate_module: unquote(aggregate),

--- a/lib/commanded/middleware/logger.ex
+++ b/lib/commanded/middleware/logger.ex
@@ -1,0 +1,42 @@
+defmodule Commanded.Middleware.Logger do
+  @behaviour Commanded.Middleware
+
+  alias Commanded.Middleware.Pipeline
+  import Pipeline
+  require Logger
+
+  def before_dispatch(%Pipeline{} = pipeline) do
+    Logger.info(fn -> "#{log_context(pipeline)} dispatch start" end)
+    assign(pipeline, :started_at, DateTime.utc_now)
+  end
+
+  def after_dispatch(%Pipeline{} = pipeline) do
+    Logger.info(fn -> "#{log_context(pipeline)} succeeded in #{formatted_diff(delta(pipeline))}" end)
+    pipeline
+  end
+
+  def after_failure(%Pipeline{assigns: %{error: error, error_reason: error_reason}} = pipeline) do
+    Logger.info(fn -> "#{log_context(pipeline)} failed #{inspect error} in #{formatted_diff(delta(pipeline))}" end)
+    Logger.info(fn -> inspect(error_reason) end)
+    pipeline
+  end
+
+  def after_failure(%Pipeline{assigns: %{error: error}} = pipeline) do
+    Logger.info(fn -> "#{log_context(pipeline)} failed #{inspect error} in #{formatted_diff(delta(pipeline))}" end)
+    pipeline
+  end
+
+  defp delta(%Pipeline{assigns: %{started_at: started_at}}) do
+    now_usecs = DateTime.utc_now |> DateTime.to_unix(:microseconds)
+    started_usecs = started_at |> DateTime.to_unix(:microseconds)
+    now_usecs - started_usecs
+  end
+
+  defp log_context(%Pipeline{command: command}) do
+    "#{inspect command.__struct__}"
+  end
+
+  defp formatted_diff(diff) when diff > 1_000_000, do: [diff |> div(1_000_000) |> Integer.to_string, "s"]
+  defp formatted_diff(diff) when diff > 1_000, do: [diff |> div(1_000) |> Integer.to_string, "ms"]
+  defp formatted_diff(diff), do: [diff |> Integer.to_string, "µs"]
+end

--- a/lib/commanded/middleware/middleware.ex
+++ b/lib/commanded/middleware/middleware.ex
@@ -1,4 +1,39 @@
 defmodule Commanded.Middleware do
+  @moduledoc """
+  Middleware provides an extension point to add functions that you want to be called for every command the router dispatches.
+
+  Examples include command validation, authorization, and logging.
+
+  Implement the `Commanded.Middleware` behaviour in your module and define the `before_dispatch`, `after_dispatch`, and `after_failure` callback functions.
+
+  ## Example middleware
+
+      defmodule NoOpMiddleware do
+        @behaviour Commanded.Middleware
+
+        alias Commanded.Middleware.Pipeline
+        import Pipeline
+
+        def before_dispatch(%Pipeline{command: command} = pipeline) do
+          pipeline
+        end
+
+        def after_dispatch(%Pipeline{command: command} = pipeline) do
+          pipeline
+        end
+
+        def after_failure(%Pipeline{command: command} = pipeline) do
+          pipeline
+        end
+      end
+
+  Import the `Commanded.Middleware.Pipeline` module to access convenience functions.
+
+    * `assign/3` - puts a key and value into the `assigns` map
+    * `halt/1` - stops execution of further middleware downstream and prevents dispatch of the command when used in a `before_dispatch` callback
+
+  """
+
   alias Commanded.Middleware.Pipeline
 
   @type pipeline :: %Pipeline{}

--- a/lib/commanded/middleware/middleware.ex
+++ b/lib/commanded/middleware/middleware.ex
@@ -1,0 +1,9 @@
+defmodule Commanded.Middleware do
+  alias Commanded.Middleware.Pipeline
+
+  @type pipeline :: %Pipeline{}
+
+  @callback before_dispatch(pipeline) :: pipeline
+  @callback after_dispatch(pipeline) :: pipeline
+  @callback after_failure(pipeline) :: pipeline
+end

--- a/lib/commanded/middleware/pipeline.ex
+++ b/lib/commanded/middleware/pipeline.ex
@@ -7,7 +7,6 @@ defmodule Commanded.Middleware.Pipeline do
   defstruct [
     assigns: %{},
     command: nil,
-    timeout: nil,
     halted: false,
     terminated: false,
   ]

--- a/lib/commanded/middleware/pipeline.ex
+++ b/lib/commanded/middleware/pipeline.ex
@@ -1,0 +1,48 @@
+defmodule Commanded.Middleware.Pipeline do
+  @moduledoc """
+  Pipeline is a struct used as an argument in the callback functions of modules implementing the `Commanded.Middleware` behaviour.
+  This struct must be returned by each function to be used in the next middleware based on the configured middleware chain.
+  """
+
+  defstruct [
+    assigns: %{},
+    command: nil,
+    timeout: nil,
+    halted: false,
+    terminated: false,
+  ]
+
+  alias Commanded.Middleware.Pipeline
+
+  @doc """
+  Puts the `key` with value equal to `value` into `assigns` map
+  """
+  def assign(%Pipeline{assigns: assigns} = pipeline, key, value) when is_atom(key) do
+    %Pipeline{pipeline | assigns: Map.put(assigns, key, value)}
+  end
+
+  @doc """
+  Sets `halted` to true
+  """
+  def halt(%Pipeline{} = pipeline) do
+    %Pipeline{pipeline | halted: true}
+  end
+
+  @doc """
+  Sets `terminated` to true
+  """
+  def terminate(%Pipeline{} = pipeline) do
+    %Pipeline{pipeline | terminated: true}
+  end
+
+  @doc """
+  Implements the middleware chain
+  """
+  def chain(pipeline, stage, middleware)
+  def chain(pipeline, _stage, []), do: pipeline
+  def chain(%Pipeline{halted: true} = pipeline, _stage, _middleware), do: pipeline
+  def chain(%Pipeline{terminated: true} = pipeline, _stage, _middleware), do: pipeline
+  def chain(pipeline, stage, [module | modules]) do
+    chain(apply(module, stage, [pipeline]), stage, modules)
+  end
+end

--- a/lib/commanded/middleware/pipeline.ex
+++ b/lib/commanded/middleware/pipeline.ex
@@ -9,6 +9,7 @@ defmodule Commanded.Middleware.Pipeline do
     * `assigns` - shared user data as a map
     * `command` - the command struct being dispatched
     * `halted` - the boolean status on whether the pipeline was halted
+    * `response` - override the response to send back to the caller (optional)
 
   """
 

--- a/lib/commanded/supervisor.ex
+++ b/lib/commanded/supervisor.ex
@@ -7,7 +7,8 @@ defmodule Commanded.Supervisor do
 
   def init(_) do
     children = [
-      worker(Commanded.Aggregates.Registry, [])
+      worker(Commanded.Aggregates.Registry, []),
+      supervisor(Task.Supervisor, [[name: Commanded.Commands.TaskDispatcher]]),
     ]
 
     supervise(children, strategy: :one_for_one)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Commanded.Mixfile do
   def project do
     [
       app: :commanded,
-      version: "0.6.3",
+      version: "0.7.0",
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env),
       description: description,

--- a/test/commands/command_timeout_test.exs
+++ b/test/commands/command_timeout_test.exs
@@ -25,7 +25,7 @@ defmodule Commanded.Commands.CommandTimeoutTest do
     dispatch TimeoutCommand, to: TimeoutCommandHandler, aggregate: StubAggregateRoot, identity: :aggregate_uuid, timeout: 500
   end
 
-  test "should allow timeout to be specified for a command registration" do
+  test "should allow timeout to be specified during command registration" do
     {_pid, ref} = spawn_monitor(fn ->
       # handler is set to take longer than the configured timeout (1s sleep vs 500ms timeout)
       :ok = TimeoutRouter.dispatch(%TimeoutCommand{sleep_in_ms: 1_000})

--- a/test/commands/command_timeout_test.exs
+++ b/test/commands/command_timeout_test.exs
@@ -22,22 +22,19 @@ defmodule Commanded.Commands.CommandTimeoutTest do
   defmodule TimeoutRouter do
     use Commanded.Commands.Router
 
-    dispatch TimeoutCommand, to: TimeoutCommandHandler, aggregate: StubAggregateRoot, identity: :aggregate_uuid, timeout: 500
+    dispatch TimeoutCommand, to: TimeoutCommandHandler, aggregate: StubAggregateRoot, identity: :aggregate_uuid, timeout: 1_000
   end
 
   test "should allow timeout to be specified during command registration" do
-    {_pid, ref} = spawn_monitor(fn ->
-      # handler is set to take longer than the configured timeout (1s sleep vs 500ms timeout)
-      :ok = TimeoutRouter.dispatch(%TimeoutCommand{sleep_in_ms: 1_000})
-    end)
-    assert_receive {:DOWN, ^ref, :process, _, {:timeout, _}}, 1_000
+    # handler is set to take longer than the configured timeout
+    {:error, :aggregate_execution_timeout} = TimeoutRouter.dispatch(%TimeoutCommand{sleep_in_ms: 2_000})
   end
 
   test "should succeed when handler completes within configured timeout" do
-    :ok = TimeoutRouter.dispatch(%TimeoutCommand{sleep_in_ms: 200})
+    :ok = TimeoutRouter.dispatch(%TimeoutCommand{sleep_in_ms: 100})
   end
 
   test "should succeed when timeout is overridden during dispatch" do
-    :ok = TimeoutRouter.dispatch(%TimeoutCommand{sleep_in_ms: 1_00}, 2_000)
+    :ok = TimeoutRouter.dispatch(%TimeoutCommand{sleep_in_ms: 100}, 2_000)
   end
 end

--- a/test/helpers/command_audit_middleware.ex
+++ b/test/helpers/command_audit_middleware.ex
@@ -38,6 +38,15 @@ defmodule Commanded.Helpers.CommandAuditMiddleware do
   end
 
   @doc """
+  Get the counts of the dispatched, succeeded, and failed commands
+  """
+  def count_commands do
+    Agent.get(__MODULE__, fn %AuditLog{dispatched: dispatched, succeeded: succeeded, failed: failed} ->
+      {length(dispatched), length(succeeded), length(failed)}
+    end)
+  end
+
+  @doc """
   Access the dispatched commands the middleware received
   """
   def dispatched_commands do

--- a/test/helpers/command_audit_middleware.ex
+++ b/test/helpers/command_audit_middleware.ex
@@ -1,0 +1,60 @@
+defmodule Commanded.Helpers.CommandAuditMiddleware do
+  @behaviour Commanded.Middleware
+
+  defmodule AuditLog do
+    defstruct [
+      dispatched: [],
+      succeeded: [],
+      failed: [],
+    ]
+  end
+
+  def start_link do
+    Agent.start_link(fn -> %AuditLog{} end, name: __MODULE__)
+  end
+
+  def before_dispatch(%{command: command} = pipeline) do
+    Agent.update(__MODULE__, fn %AuditLog{dispatched: dispatched} = audit ->
+      %AuditLog{audit | dispatched: dispatched ++ [command]}
+    end)
+
+    pipeline
+  end
+
+  def after_dispatch(%{command: command} = pipeline) do
+    Agent.update(__MODULE__, fn %AuditLog{succeeded: succeeded} = audit ->
+      %AuditLog{audit | succeeded: succeeded ++ [command]}
+    end)
+
+    pipeline
+  end
+
+  def after_failure(%{command: command} = pipeline) do
+    Agent.update(__MODULE__, fn %AuditLog{failed: failed} = audit ->
+      %AuditLog{audit | failed: failed ++ [command]}
+    end)
+
+    pipeline
+  end
+
+  @doc """
+  Access the dispatched commands the middleware received
+  """
+  def dispatched_commands do
+    Agent.get(__MODULE__, fn %AuditLog{dispatched: dispatched} -> dispatched end)
+  end
+
+  @doc """
+  Access the dispatched commands that successfully executed
+  """
+  def succeeded_commands do
+    Agent.get(__MODULE__, fn %AuditLog{succeeded: succeeded} -> succeeded end)
+  end
+
+  @doc """
+  Access the dispatched commands that failed to execute
+  """
+  def failed_commands do
+    Agent.get(__MODULE__, fn %AuditLog{failed: failed} -> failed end)
+  end
+end

--- a/test/helpers/commands/commands.ex
+++ b/test/helpers/commands/commands.ex
@@ -1,0 +1,62 @@
+defmodule Commanded.Helpers.Commands do
+  defmodule IncrementCount do
+    defstruct aggregate_uuid: nil, by: 1
+  end
+
+  defmodule Fail do
+    defstruct [:aggregate_uuid]
+  end
+
+  defmodule RaiseError do
+    defstruct [:aggregate_uuid]
+  end
+
+  defmodule Timeout do
+    defstruct [:aggregate_uuid]
+  end
+
+  defmodule Validate do
+    defstruct [:aggregate_uuid, :valid?]
+  end
+
+  defmodule CountIncremented do
+    defstruct [:count]
+  end
+
+  defmodule CounterAggregateRoot do
+    use EventSourced.AggregateRoot, fields: [count: 0]
+
+    def increment(%CounterAggregateRoot{state: %{count: count}} = counter, increment_by) when is_integer(increment_by) do
+      {:ok, update(counter, %CountIncremented{count: count + increment_by})}
+    end
+
+    def apply(%CounterAggregateRoot.State{} = state, %CountIncremented{count: count}) do
+      %CounterAggregateRoot.State{state | count: count}
+    end
+  end
+
+  defmodule CommandHandler do
+    @behaviour Commanded.Commands.Handler
+
+    def handle(%CounterAggregateRoot{} = aggregate, %IncrementCount{by: by}) do
+      CounterAggregateRoot.increment(aggregate, by)
+    end
+
+    def handle(%CounterAggregateRoot{}, %Fail{}) do
+      {:error, :failed}
+    end
+
+    def handle(%CounterAggregateRoot{}, %RaiseError{}) do
+      raise "failed"
+    end
+
+    def handle(%CounterAggregateRoot{} = aggregate, %Timeout{}) do
+      :timer.sleep 1_000
+      {:ok, aggregate}
+    end
+
+    def handle(%CounterAggregateRoot{} = aggregate, %Validate{}) do
+      {:ok, aggregate}
+    end
+  end
+end

--- a/test/middleware/halting_middleware_test.exs
+++ b/test/middleware/halting_middleware_test.exs
@@ -52,20 +52,18 @@ defmodule Commanded.Commands.Middleware.HaltingMiddlewareTest do
     dispatch Validate, to: CommandHandler, aggregate: CounterAggregateRoot, identity: :aggregate_uuid
   end
 
-  @tag :wip
   test "should not dispatch the command when middleware halts pipeline" do
     {:ok, _} = CommandAuditMiddleware.start_link
 
     {:error, :halted} = HaltingRouter.dispatch(%IncrementCount{aggregate_uuid: UUID.uuid4})
 
     {dispatched, succeeded, failed} = CommandAuditMiddleware.count_commands
-    
+
     assert dispatched == 1
     assert succeeded == 0
     assert failed == 0
   end
 
-  @tag :wip
   test "should allow middleware to set dispatch response" do
     {:ok, _} = CommandAuditMiddleware.start_link
 

--- a/test/middleware/halting_middleware_test.exs
+++ b/test/middleware/halting_middleware_test.exs
@@ -1,0 +1,80 @@
+defmodule Commanded.Commands.Middleware.HaltingMiddlewareTest do
+  use Commanded.StorageCase
+
+  alias Commanded.Helpers.CommandAuditMiddleware
+  alias Commanded.Helpers.Commands.{IncrementCount,Validate,CommandHandler,CounterAggregateRoot}
+
+  defmodule HaltingMiddleware do
+    @behaviour Commanded.Middleware
+
+    import Commanded.Middleware.Pipeline
+
+    def before_dispatch(pipeline), do: halt(pipeline)
+    def after_dispatch(pipeline), do: pipeline
+    def after_failure(pipeline), do: pipeline
+  end
+
+  defmodule ValidationMiddleware do
+    @behaviour Commanded.Middleware
+
+    alias Commanded.Middleware.Pipeline
+    import Pipeline
+
+    def before_dispatch(%Pipeline{command: command} = pipeline) do
+      case Map.get(command, :valid?, false) do
+        true -> pipeline
+        false ->
+          pipeline
+          |> respond({:error, :validation_failure})
+          |> halt
+      end
+    end
+
+    def after_dispatch(pipeline), do: pipeline
+    def after_failure(pipeline), do: pipeline
+  end
+
+  defmodule HaltingRouter do
+    use Commanded.Commands.Router
+
+    middleware CommandAuditMiddleware
+    middleware HaltingMiddleware
+
+    dispatch IncrementCount, to: CommandHandler, aggregate: CounterAggregateRoot, identity: :aggregate_uuid
+  end
+
+  defmodule ValidatingRouter do
+    use Commanded.Commands.Router
+
+    middleware CommandAuditMiddleware
+    middleware ValidationMiddleware
+
+    dispatch Validate, to: CommandHandler, aggregate: CounterAggregateRoot, identity: :aggregate_uuid
+  end
+
+  @tag :wip
+  test "should not dispatch the command when middleware halts pipeline" do
+    {:ok, _} = CommandAuditMiddleware.start_link
+
+    {:error, :halted} = HaltingRouter.dispatch(%IncrementCount{aggregate_uuid: UUID.uuid4})
+
+    {dispatched, succeeded, failed} = CommandAuditMiddleware.count_commands
+    
+    assert dispatched == 1
+    assert succeeded == 0
+    assert failed == 0
+  end
+
+  @tag :wip
+  test "should allow middleware to set dispatch response" do
+    {:ok, _} = CommandAuditMiddleware.start_link
+
+    {:error, :validation_failure} = ValidatingRouter.dispatch(%Validate{aggregate_uuid: UUID.uuid4, valid?: false})
+
+    {dispatched, succeeded, failed} = CommandAuditMiddleware.count_commands
+
+    assert dispatched == 1
+    assert succeeded == 0
+    assert failed == 0
+  end
+end

--- a/test/middleware/middleware_test.exs
+++ b/test/middleware/middleware_test.exs
@@ -1,0 +1,86 @@
+defmodule Commanded.Commands.Middleware.MiddlewareTest do
+  use Commanded.StorageCase
+
+  import Commanded.Enumerable
+
+  alias Commanded.Helpers.CommandAuditMiddleware
+
+  defmodule IncrementCount do
+    defstruct aggregate_uuid: nil, by: 1
+  end
+
+  defmodule Fail do
+    defstruct aggregate_uuid: nil
+  end
+
+  defmodule CountIncremented do
+    defstruct [:count]
+  end
+
+  defmodule CounterAggregateRoot do
+    use EventSourced.AggregateRoot, fields: [count: 0]
+
+    def increment(%CounterAggregateRoot{state: %{count: count}} = counter, increment_by) when is_integer(increment_by) do
+      {:ok, update(counter, %CountIncremented{count: count + increment_by})}
+    end
+
+    def apply(%CounterAggregateRoot.State{} = state, %CountIncremented{count: count}) do
+      %CounterAggregateRoot.State{state | count: count}
+    end
+  end
+
+  defmodule CommandHandler do
+    @behaviour Commanded.Commands.Handler
+
+    def handle(%CounterAggregateRoot{} = aggregate, %IncrementCount{by: by}) do
+      CounterAggregateRoot.increment(aggregate, by)
+    end
+  end
+
+  defmodule FirstMiddleware do
+    @behaviour Commanded.Middleware
+
+    def before_dispatch(pipeline), do: pipeline
+    def after_dispatch(pipeline), do: pipeline
+    def after_failure(pipeline), do: pipeline
+  end
+
+  defmodule LastMiddleware do
+    @behaviour Commanded.Middleware
+
+    def before_dispatch(pipeline), do: pipeline
+    def after_dispatch(pipeline), do: pipeline
+    def after_failure(pipeline), do: pipeline
+  end
+
+  defmodule Router do
+    use Commanded.Commands.Router
+
+    middleware FirstMiddleware
+    middleware CommandAuditMiddleware
+    middleware LastMiddleware
+
+    dispatch IncrementCount, to: CommandHandler, aggregate: CounterAggregateRoot, identity: :aggregate_uuid
+  end
+
+  @tag :wip
+  test "should call middleware for each command dispatch" do
+    aggregate_uuid = UUID.uuid4
+
+    {:ok, _} = CommandAuditMiddleware.start_link
+
+    :ok = Router.dispatch(%IncrementCount{aggregate_uuid: aggregate_uuid, by: 1})
+    :ok = Router.dispatch(%IncrementCount{aggregate_uuid: aggregate_uuid, by: 2})
+    :ok = Router.dispatch(%IncrementCount{aggregate_uuid: aggregate_uuid, by: 3})
+
+    dispatched_commands = CommandAuditMiddleware.dispatched_commands
+    succeeded_commands = CommandAuditMiddleware.succeeded_commands
+    failed_commands = CommandAuditMiddleware.failed_commands
+
+    assert length(dispatched_commands) == 3
+    assert length(succeeded_commands) == 3
+    assert length(failed_commands) == 0
+    assert pluck(dispatched_commands, :by) == [1, 2, 3]
+    assert pluck(succeeded_commands, :by) == [1, 2, 3]
+  end
+end

--- a/test/middleware/middleware_test.exs
+++ b/test/middleware/middleware_test.exs
@@ -4,59 +4,7 @@ defmodule Commanded.Commands.Middleware.MiddlewareTest do
   import Commanded.Enumerable
 
   alias Commanded.Helpers.CommandAuditMiddleware
-
-  defmodule IncrementCount do
-    defstruct aggregate_uuid: nil, by: 1
-  end
-
-  defmodule Fail do
-    defstruct [:aggregate_uuid]
-  end
-
-  defmodule RaiseError do
-    defstruct [:aggregate_uuid]
-  end
-
-  defmodule Timeout do
-    defstruct [:aggregate_uuid]
-  end
-
-  defmodule CountIncremented do
-    defstruct [:count]
-  end
-
-  defmodule CounterAggregateRoot do
-    use EventSourced.AggregateRoot, fields: [count: 0]
-
-    def increment(%CounterAggregateRoot{state: %{count: count}} = counter, increment_by) when is_integer(increment_by) do
-      {:ok, update(counter, %CountIncremented{count: count + increment_by})}
-    end
-
-    def apply(%CounterAggregateRoot.State{} = state, %CountIncremented{count: count}) do
-      %CounterAggregateRoot.State{state | count: count}
-    end
-  end
-
-  defmodule CommandHandler do
-    @behaviour Commanded.Commands.Handler
-
-    def handle(%CounterAggregateRoot{} = aggregate, %IncrementCount{by: by}) do
-      CounterAggregateRoot.increment(aggregate, by)
-    end
-
-    def handle(%CounterAggregateRoot{}, %Fail{}) do
-      {:error, :failed}
-    end
-
-    def handle(%CounterAggregateRoot{}, %RaiseError{}) do
-      raise "failed"
-    end
-
-    def handle(%CounterAggregateRoot{} = aggregate, %Timeout{}) do
-      :timer.sleep 1_000
-      {:ok, aggregate}
-    end
-  end
+  alias Commanded.Helpers.Commands.{IncrementCount,Fail,RaiseError,Timeout,CommandHandler,CounterAggregateRoot}
 
   defmodule FirstMiddleware do
     @behaviour Commanded.Middleware
@@ -99,65 +47,55 @@ defmodule Commanded.Commands.Middleware.MiddlewareTest do
     :ok = Router.dispatch(%IncrementCount{aggregate_uuid: aggregate_uuid, by: 2})
     :ok = Router.dispatch(%IncrementCount{aggregate_uuid: aggregate_uuid, by: 3})
 
-    dispatched_commands = CommandAuditMiddleware.dispatched_commands
-    succeeded_commands = CommandAuditMiddleware.succeeded_commands
-    failed_commands = CommandAuditMiddleware.failed_commands
+    {dispatched, succeeded, failed} = CommandAuditMiddleware.count_commands
 
-    assert length(dispatched_commands) == 3
-    assert length(succeeded_commands) == 3
-    assert length(failed_commands) == 0
+    assert dispatched == 3
+    assert succeeded == 3
+    assert failed == 0
+
+    dispatched_commands = CommandAuditMiddleware.dispatched_commands
+    succeeded_commands = CommandAuditMiddleware.dispatched_commands
+
     assert pluck(dispatched_commands, :by) == [1, 2, 3]
     assert pluck(succeeded_commands, :by) == [1, 2, 3]
   end
 
   test "should execute middleware failure callback when aggregate process returns an error tagged tuple" do
-    aggregate_uuid = UUID.uuid4
-
     {:ok, _} = CommandAuditMiddleware.start_link
 
     # force command handling to return an error
-    {:error, :failed} = Router.dispatch(%Fail{aggregate_uuid: aggregate_uuid})
+    {:error, :failed} = Router.dispatch(%Fail{aggregate_uuid: UUID.uuid4})
 
-    dispatched_commands = CommandAuditMiddleware.dispatched_commands
-    succeeded_commands = CommandAuditMiddleware.succeeded_commands
-    failed_commands = CommandAuditMiddleware.failed_commands
+    {dispatched, succeeded, failed} = CommandAuditMiddleware.count_commands
 
-    assert length(dispatched_commands) == 1
-    assert length(succeeded_commands) == 0
-    assert length(failed_commands) == 1
+    assert dispatched == 1
+    assert succeeded == 0
+    assert failed == 1
   end
 
   test "should execute middleware failure callback when aggregate process errors" do
-    aggregate_uuid = UUID.uuid4
-
     {:ok, _} = CommandAuditMiddleware.start_link
 
     # force command handling to error
-    {:error, :aggregate_execution_failed} = Router.dispatch(%RaiseError{aggregate_uuid: aggregate_uuid})
+    {:error, :aggregate_execution_failed} = Router.dispatch(%RaiseError{aggregate_uuid: UUID.uuid4})
 
-    dispatched_commands = CommandAuditMiddleware.dispatched_commands
-    succeeded_commands = CommandAuditMiddleware.succeeded_commands
-    failed_commands = CommandAuditMiddleware.failed_commands
+    {dispatched, succeeded, failed} = CommandAuditMiddleware.count_commands
 
-    assert length(dispatched_commands) == 1
-    assert length(succeeded_commands) == 0
-    assert length(failed_commands) == 1
+    assert dispatched == 1
+    assert succeeded == 0
+    assert failed == 1
   end
 
   test "should execute middleware failure callback when aggregate process dies" do
-    aggregate_uuid = UUID.uuid4
-
     {:ok, _} = CommandAuditMiddleware.start_link
 
     # force command handling to timeout so the aggregate process is terminated
-    {:error, :aggregate_execution_timeout} = Router.dispatch(%Timeout{aggregate_uuid: aggregate_uuid}, 50)
+    {:error, :aggregate_execution_timeout} = Router.dispatch(%Timeout{aggregate_uuid: UUID.uuid4}, 50)
 
-    dispatched_commands = CommandAuditMiddleware.dispatched_commands
-    succeeded_commands = CommandAuditMiddleware.succeeded_commands
-    failed_commands = CommandAuditMiddleware.failed_commands
+    {dispatched, succeeded, failed} = CommandAuditMiddleware.count_commands
 
-    assert length(dispatched_commands) == 1
-    assert length(succeeded_commands) == 0
-    assert length(failed_commands) == 1
+    assert dispatched == 1
+    assert succeeded == 0
+    assert failed == 1
   end
 end

--- a/test/middleware/middleware_test.exs
+++ b/test/middleware/middleware_test.exs
@@ -90,7 +90,6 @@ defmodule Commanded.Commands.Middleware.MiddlewareTest do
     ], to: CommandHandler, aggregate: CounterAggregateRoot, identity: :aggregate_uuid
   end
 
-  @tag :wip
   test "should call middleware for each command dispatch" do
     aggregate_uuid = UUID.uuid4
 
@@ -111,7 +110,6 @@ defmodule Commanded.Commands.Middleware.MiddlewareTest do
     assert pluck(succeeded_commands, :by) == [1, 2, 3]
   end
 
-  @tag :wip
   test "should execute middleware failure callback when aggregate process returns an error tagged tuple" do
     aggregate_uuid = UUID.uuid4
 
@@ -129,7 +127,6 @@ defmodule Commanded.Commands.Middleware.MiddlewareTest do
     assert length(failed_commands) == 1
   end
 
-  @tag :wip
   test "should execute middleware failure callback when aggregate process errors" do
     aggregate_uuid = UUID.uuid4
 
@@ -147,14 +144,13 @@ defmodule Commanded.Commands.Middleware.MiddlewareTest do
     assert length(failed_commands) == 1
   end
 
-  @tag :wip
   test "should execute middleware failure callback when aggregate process dies" do
     aggregate_uuid = UUID.uuid4
 
     {:ok, _} = CommandAuditMiddleware.start_link
 
     # force command handling to timeout so the aggregate process is terminated
-    {:error, :aggregate_execution_timeout} = reply = Router.dispatch(%Timeout{aggregate_uuid: aggregate_uuid}, 50)
+    {:error, :aggregate_execution_timeout} = Router.dispatch(%Timeout{aggregate_uuid: aggregate_uuid}, 50)
 
     dispatched_commands = CommandAuditMiddleware.dispatched_commands
     succeeded_commands = CommandAuditMiddleware.succeeded_commands


### PR DESCRIPTION
Allow a command router to define middleware modules that are executed before and after success or failure of each command dispatch.

This provides an extension point to add in typical behaviour that you want to be called for every command the router dispatches command (e.g. validation, authorization, logging, etc.).

It follows, and is heavily inspired by, the [middleware approach taken by Exq](https://github.com/akira/exq#middleware-support).

```elixir
defmodule BankingRouter do
  use Commanded.Commands.Router

  middleware Commanded.Logger
  middleware MyCommandValidator
  middleware AuthorizeCommand

  dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
  dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount, identity: :account_number
end
```

Middleware modules are executed in the order they’ve been defined. They will receive a `Commanded.Middleware.Pipeline` struct containing the command being dispatched.

## Module middleware

```elixir
defmodule MyMiddleware do
  @behaviour Commanded.Commands.Middleware

  alias Commanded.Middleware.Pipeline
  import Pipeline

  def before_dispatch(%Pipeline{command: command} = pipeline) do   
    pipeline
  end

  def after_dispatch(%Pipeline{} = pipeline) do   
    pipeline
  end

  def after_failure(%Pipeline{} = pipeline) do   
    pipeline
  end
end
```

Fixes #12 .