### PR TITLE
Simplify aggregate roots and process managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Commanded
 
-Command handling middleware for CQRS applications in Elixir.
+Command handling middleware for Command Query Responsibility Segregation (CQRS) applications in Elixir. Use Commanded to build your own applications following the [CQRS/ES](http://cqrs.nu/Faq) architecture.
 
 Provides support for command registration and dispatch; hosting and delegation to aggregate roots; event handling; and long running process managers.
 
-Use with [eventstore](https://github.com/slashdotdash/eventstore) and [eventsourced](https://github.com/slashdotdash/eventsourced) as components that comprise a [CQRS](http://cqrs.nu/Faq) framework for Elixir.
+Uses [eventstore](https://github.com/slashdotdash/eventstore) for persistence to PostgreSQL.
 
 MIT License
 
@@ -12,13 +12,13 @@ MIT License
 
 ## Getting started
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed as:
+The package can be installed from hex as follows.
 
   1. Add commanded to your list of dependencies in `mix.exs`:
 
     ```elixir
     def deps do
-      [{:commanded, "~> 0.7"}]
+      [{:commanded, "~> 0.8"}]
     end
     ```
 
@@ -30,7 +30,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
     end
     ```
 
-  3. Configure the `eventstore` in each environment's mix config file (e.g. `config/dev/exs`), specifying usage of the JSON serializer:
+  3. Configure the `eventstore` in each environment's mix config file (e.g. `config/dev.exs`), specifying usage of the included JSON serializer:
 
     ```elixir
     config :eventstore, EventStore.Storage,
@@ -43,7 +43,7 @@ If [available in Hex](https://hex.pm/docs/publish), the package can be installed
       extensions: [{Postgrex.Extensions.Calendar, []}]
     ```
 
-  4. Create the `eventstore` database and tables using the `mix` task
+  4. Create the `eventstore` database and tables using the `mix` task.
 
     ```
     mix event_store.create
@@ -61,30 +61,48 @@ You may manually start the top level Supervisor process.
 
 ### Aggregate roots
 
-Use the [eventsourced](https://github.com/slashdotdash/eventsourced) library to build your aggregate roots. This is the expected approach to writing event-sourced domain models.
+Build your aggregate roots using standard Elixir modules and functions, with structs to hold state. There is no external dependency requirement.
 
-Follow the convention of returning an `{:ok, aggregate}` tuple on success. For business rule violations and errors you should return an `{:error, reason}` tuple.
+An aggregate root is comprised of its state, public command functions, and state mutators.
+
+#### Command functions
+
+A command function receives the aggregate root's state and the command to execute. It must return the resultant domain events. This may be none, one, or multiple events.
+
+For business rule violations and errors you may return an `{:error, reason}` tagged tuple or raise an exception.
+
+#### State mutators
+
+The state of an aggregate root can only be mutated by applying a raised domain event to its state. This is achieved by an `apply/2` function that receives the state and the domain event. It returns the modified state.
+
+Pattern matching is used to invoke the respective `apply/2` function for an event. These functions *must never fail* as they are used when rebuilding the aggregate state from its history of raised domain events. You cannot reject the event once it has occurred.
+
+#### Example aggregate root
 
 ```elixir
 defmodule BankAccount do
-  use EventSourced.AggregateRoot, fields: [account_number: nil, balance: nil]
+  defstruct [account_number: nil, balance: nil]
 
   # public command API
 
-  def open_account(%BankAccount{} = account, account_number, initial_balance) when initial_balance <= 0 do
-    {:error, :initial_balance_must_be_above_zero}
+  def open_account(%BankAccount{} = account, account_number, initial_balance)
+    when initial_balance > 0
+  do
+    %BankAccountOpened{account_number: account_number, initial_balance: initial_balance}
   end
 
-  def open_account(%BankAccount{} = account, account_number, initial_balance) when initial_balance > 0 do
-    {:ok, update(account, %BankAccountOpened{account_number: account_number, initial_balance: initial_balance})}
+  def open_account(%BankAccount{} = account, account_number, initial_balance)
+    when initial_balance <= 0
+  do
+    {:error, :initial_balance_must_be_above_zero}
   end
 
   # state mutators
 
-  def apply(%BankAccount.State{} = state, %BankAccountOpened{} = account_opened) do
-    %BankAccount.State{state|
-      account_number: account_opened.account_number,
-      balance: account_opened.initial_balance
+  def apply(%BankAccount{} = account, %BankAccountOpened{account_number: account_number, initial_balance: initial_balance}) do
+    %BankAccount{account |
+      account_number: account_number,
+      balance: initial_balance
     }
   end
 end
@@ -104,7 +122,7 @@ end
 
 Implement the `Commanded.Commands.Handler` behaviour consisting of a single `handle/2` function.
 
-It receives the aggregate root and the command to be handled. It must return an `{:ok, aggregate_root}` tuple on success, otherwise an `{:error, reason}` tuple on failure.
+It receives the aggregate root state and the command to be handled. It must return the raised domain events from the aggregate root. It may return an `{:error, reason}` tuple on failure.
 
 ```elixir
 defmodule OpenAccountHandler do
@@ -138,7 +156,7 @@ You can then dispatch a command using the router.
 
 #### Timeouts
 
-A command handler has a default timeout of 5 seconds. The same as a `GenServer` process call. It must handle the command in this period, otherwise the call fails and the caller exits.
+A command handler has a default timeout of 5 seconds. The same default as a `GenServer` process call. It must handle the command in this period, otherwise the call fails and the caller exits.
 
 You can configure a different timeout value during command registration or dispatch.
 
@@ -240,10 +258,8 @@ defmodule AccountBalanceHandler do
     Agent.update(__MODULE__, fn _ -> balance end)
   end
 
-  def handle(_event, _metadata) do
-    # ignore all other events
-    :ok
-  end
+  # ignore all other events
+  def handle(_event, _metadata), do: :ok
 
   def current_balance do
     Agent.get(__MODULE__, fn balance -> balance end)
@@ -262,23 +278,32 @@ Register the event handler with a given name. The name is used when subscribing 
 
 A process manager is responsible for coordinating one or more aggregate roots.
 
-It handles events and may dispatch one or more commands in response. Process managers have state that can be used to track which aggregate roots are being coordinated.
+It handles events and may dispatch commands in response. Process managers have state that can be used to track which aggregate roots are being orchestrated.
 
-A process manager must implement the `interested?/1` function to indicate which events are used. The response is used to route the event to an existing instance or start a new process.
+A process manager must implement the `Commanded.ProcessManagers.ProcessManager` behaviour. It defines three callback functions: `interested?/1`, `handle/2`, and `apply/2`.
+
+#### `interested?/1`
+
+The `interested?/1` function is used to indicate which events the process manager receives. The response is used to route the event to an existing instance or start a new process instance.
 
 - Return `{:start, process_uuid}` to create a new instance of the process manager.
 - Return `{:continue, process_uuid}` to continue execution of an existing process manager.
-- Return `false` to ignore the event
+- Return `false` to ignore the event.
 
-A `handle/2` function must exist for each interested event. It receives the process manager's state and the event to be handled. It must return the state, including any commands that should be dispatched.
+#### `handle/2`
 
-Use the `Commanded.ProcessManagers.ProcessManager` macro to define the required state for your process manager. The `dispatch/2` function is used to dispatch a command. This can be called multiple times to dispatch more than one command in response to a received domain event. The process manager's state is updated by calling the `update/2` function. This delegates to an `apply/2` function that mutates the state.
+A `handle/2` function must exist for each interested event previously specified. It receives the process manager's state and the event to be handled. It must return the commands to be dispatched. This may be none, a single command, or many commands.
 
-Each process manager `handle/2` function should return an `{:ok, process_manager}` success tuple.
+#### `apply/2`
+
+The `apply/2` function is used to mutate the process manager's state. It receives its current state and the interested event. It must return the modified state.
 
 ```elixir
 defmodule TransferMoneyProcessManager do
-  use Commanded.ProcessManagers.ProcessManager, fields: [
+  @behaviour Commanded.ProcessManagers.ProcessManager
+
+  defstruct [
+    transfer_uuid: nil,
     debit_account: nil,
     credit_account: nil,
     amount: nil,
@@ -290,34 +315,21 @@ defmodule TransferMoneyProcessManager do
   def interested?(%MoneyDeposited{transfer_uuid: transfer_uuid}), do: {:continue, transfer_uuid}
   def interested?(_event), do: false
 
-  def handle(%TransferMoneyProcessManager{process_uuid: transfer_uuid} = transfer, %MoneyTransferRequested{debit_account: debit_account, credit_account: credit_account, amount: amount} = money_transfer_requested) do
-    transfer =
-      transfer
-      |> dispatch(%WithdrawMoney{account_number: debit_account, transfer_uuid: transfer_uuid, amount: amount})
-      |> update(money_transfer_requested)
-
-    {:ok, transfer}
+  def handle(%TransferMoneyProcessManager{}, %MoneyTransferRequested{transfer_uuid: transfer_uuid, debit_account: debit_account, amount: amount}) do
+    %WithdrawMoney{account_number: debit_account, transfer_uuid: transfer_uuid, amount: amount}
   end
 
-  def handle(%TransferMoneyProcessManager{process_uuid: transfer_uuid, state: state} = transfer, %MoneyWithdrawn{} = money_withdrawn) do
-    transfer =
-      transfer
-      |> dispatch(%DepositMoney{account_number: state.credit_account, transfer_uuid: transfer_uuid, amount: state.amount})
-      |> update(money_withdrawn)
-
-    {:ok, transfer}
+  def handle(%TransferMoneyProcessManager{transfer_uuid: transfer_uuid, credit_account: credit_account, amount: amount}, %MoneyWithdrawn{}) do
+    %DepositMoney{account_number: credit_account, transfer_uuid: transfer_uuid, amount: amount}
   end
 
-  def handle(%TransferMoneyProcessManager{} = transfer, %MoneyDeposited{} = money_deposited) do
-    transfer = update(transfer, money_deposited)
-
-    {:ok, transfer}
-  end
+  def handle(%TransferMoneyProcessManager{}, %MoneyDeposited{}), do: []
 
   ## state mutators
 
-  def apply(%TransferMoneyProcessManager.State{} = transfer, %MoneyTransferRequested{debit_account: debit_account, credit_account: credit_account, amount: amount}) do
-    %TransferMoneyProcessManager.State{transfer |
+  def apply(%TransferMoneyProcessManager{} = transfer, %MoneyTransferRequested{transfer_uuid: transfer_uuid, debit_account: debit_account, credit_account: credit_account, amount: amount}) do
+    %TransferMoneyProcessManager{transfer |
+      transfer_uuid: transfer_uuid,
       debit_account: debit_account,
       credit_account: credit_account,
       amount: amount,
@@ -325,28 +337,27 @@ defmodule TransferMoneyProcessManager do
     }
   end
 
-  def apply(%TransferMoneyProcessManager.State{} = transfer, %MoneyWithdrawn{}) do
-    %TransferMoneyProcessManager.State{transfer |
+  def apply(%TransferMoneyProcessManager{} = transfer, %MoneyWithdrawn{}) do
+    %TransferMoneyProcessManager{transfer |
       status: :deposit_money_in_credit_account
     }
   end
 
-  def apply(%TransferMoneyProcessManager.State{} = transfer, %MoneyDeposited{}) do
-    %TransferMoneyProcessManager.State{transfer |
+  def apply(%TransferMoneyProcessManager{} = transfer, %MoneyDeposited{}) do
+    %TransferMoneyProcessManager{transfer |
       status: :transfer_complete
     }
   end
 end
-
 ```
 
-Register the process manager router, with a uniquely identified name. This is used when subscribing to events from the event store to track the last seen event and ensure they are only received once.
+Register the process manager router with a uniquely identified name. This is used when subscribing to events from the event store to track the last seen event and ensure they are only received once.
 
 ```elixir
 {:ok, _} = Commanded.ProcessManagers.Router.start_link("transfer_money_process_manager", TransferMoneyProcessManager)
 ```
 
-Process manager instance state is persisted to storage after each handled event. This allows the a process manager to resume should the host process terminate.
+Process manager instance state is persisted to storage after each handled event. This allows the process manager to resume should the host process terminate.
 
 ### Supervision
 
@@ -397,7 +408,9 @@ end
 
 ### Serialization
 
-JSON serialization is used by default for event and snapshot data. The included `Commanded.Serialization.JsonSerializer` module provides an extension point to allow additional decoding of the deserialized value. This can be used for parsing data into valid structures, such as date/time parsing from a string.
+JSON serialization is used by default for event and snapshot data.
+
+The included `Commanded.Serialization.JsonSerializer` module provides an extension point to allow additional decoding of the deserialized value. This can be used for parsing data into valid structures, such as date/time parsing from a string.
 
 The example event below has an implementation of the `Commanded.Serialization.JsonDecoder` protocol to parse the date into a `NaiveDateTime` struct.
 
@@ -417,6 +430,8 @@ defimpl Commanded.Serialization.JsonDecoder, for: ExampleEvent do
   end
 end
 ```
+
+You can implement the `EventStore.Serializer` behaviour to use an alternative serialization format if preferred.
 
 ## Contributing
 

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -131,7 +131,7 @@ defmodule Commanded.Aggregates.Aggregate do
 
   defp execute_command(command, handler, %Aggregate{aggregate_uuid: aggregate_uuid, aggregate_version: expected_version, aggregate_state: aggregate_state, aggregate_module: aggregate_module} = state) do
     case execute_command(handler, aggregate_state, command) do
-      {:error, reason} = reply -> {reply, state}
+      {:error, _reason} = reply -> {reply, state}
       nil -> {:ok, state}
       [] -> {:ok, state}
       events ->

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -50,8 +50,9 @@ defmodule Commanded.Commands.Dispatcher do
     {:ok, aggregate} = open_aggregate(payload, aggregate_uuid)
 
     task = Task.Supervisor.async_nolink(Commanded.Commands.TaskDispatcher, Aggregates.Aggregate, :execute, [aggregate, command, handler_module, timeout])
-
-    result = case Task.yield(task, timeout) || Task.shutdown(task) do
+    task_result = Task.yield(task, timeout) || Task.shutdown(task)
+    
+    result = case task_result do
       {:ok, reply} -> reply
       {:error, reason} -> {:error, :aggregate_execution_failed, reason}
       {:exit, reason} -> {:error, :aggregate_execution_failed, reason}

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -22,7 +22,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
       process_manager_name: process_manager_name,
       process_manager_module: process_manager_module,
       process_uuid: process_uuid,
-      process_state: process_manager_module.new(process_uuid),
+      process_state: struct(process_manager_module),
     })
   end
 
@@ -46,20 +46,22 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   end
 
   def handle_call({:process_state}, _from, %ProcessManagerInstance{process_state: process_state} = state) do
-    {:reply, process_state.state, state}
+    {:reply, process_state, state}
   end
 
   @doc """
   Attempt to fetch intial process state from snapshot storage
   """
-  def handle_cast({:fetch_state}, %ProcessManagerInstance{process_uuid: process_uuid, process_manager_module: process_manager_module} = state) do
+  def handle_cast({:fetch_state}, %ProcessManagerInstance{} = state) do
     state = case EventStore.read_snapshot(process_state_uuid(state)) do
       {:ok, snapshot} ->
         %ProcessManagerInstance{state |
-          process_state: process_manager_module.new(process_uuid, snapshot.data),
+          process_state: snapshot.data,
           last_seen_event_id: snapshot.source_version,
         }
-      {:error, :snapshot_not_found} -> state
+
+      {:error, :snapshot_not_found} ->
+        state
     end
 
     {:noreply, state}
@@ -69,7 +71,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   Handle the given event, using the process manager module, against the current process state
   """
   def handle_cast({:process_event, %EventStore.RecordedEvent{event_id: event_id} = event, process_router}, %ProcessManagerInstance{last_seen_event_id: last_seen_event_id} = state)
-  when not is_nil(last_seen_event_id) and event_id <= last_seen_event_id
+    when not is_nil(last_seen_event_id) and event_id <= last_seen_event_id
   do
     # already seen event, so just ack
     ack_event(event, process_router)
@@ -78,43 +80,52 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   end
 
   def handle_cast({:process_event, %EventStore.RecordedEvent{event_id: event_id} = event, process_router}, %ProcessManagerInstance{command_dispatcher: command_dispatcher, process_manager_module: process_manager_module, process_state: process_state} = state) do
-    process_state =
-      process_state
-      |> do_process_event(event, process_manager_module)
-      |> dispatch_commands(command_dispatcher)
+    case handle_event(process_manager_module, process_state, event) do
+      {:error, reason} ->
+        Logger.warn(fn -> "process manager instance failed to handle event id #{inspect event_id} due to: #{inspect reason}" end)
+        {:noreply, state}
 
-    state = %ProcessManagerInstance{state |
-      process_state: process_state,
-      last_seen_event_id: event_id,
-    }
+      commands ->
+        :ok = dispatch_commands(List.wrap(commands), command_dispatcher)
 
-    persist_state(state, event_id)
-    ack_event(event, process_router)
+        process_state = mutate_state(process_manager_module, process_state, event)
 
-    {:noreply, state}
+        state = %ProcessManagerInstance{state |
+          process_state: process_state,
+          last_seen_event_id: event_id,
+        }
+
+        persist_state(state, event_id)
+        ack_event(event, process_router)
+
+        {:noreply, state}
+    end
   end
 
-  defp do_process_event(process_state, %EventStore.RecordedEvent{data: data}, process_manager_module) do
-    {:ok, process_state} = process_manager_module.handle(process_state, data)
-    process_state
+  # process instance is given the event and returns applicable commands (may be none, one or many)
+  defp handle_event(process_manager_module, process_state, %EventStore.RecordedEvent{data: data}) do
+    process_manager_module.handle(process_state, data)
   end
 
-  defp dispatch_commands(%{commands: []} = process_state, _command_dispatcher), do: process_state
-  defp dispatch_commands(%{commands: commands} = process_state, command_dispatcher) when is_list(commands) do
+  # update the process instance's state by applying the event
+  defp mutate_state(process_manager_module, process_state, %EventStore.RecordedEvent{data: data}) do
+    process_manager_module.apply(process_state, data)
+  end
+
+  defp dispatch_commands([], _command_dispatcher), do: :ok
+  defp dispatch_commands(commands, command_dispatcher) when is_list(commands) do
     Enum.each(commands, fn command ->
       Logger.debug(fn -> "process manager instance attempting to dispatch command: #{inspect command}" end)
       :ok = command_dispatcher.dispatch(command)
     end)
-
-    %{process_state | commands: []}
   end
 
   defp persist_state(%ProcessManagerInstance{process_manager_module: process_manager_module, process_state: process_state} = state, event_id) do
     :ok = EventStore.record_snapshot(%EventStore.Snapshots.SnapshotData{
       source_uuid: process_state_uuid(state),
       source_version: event_id,
-      source_type: Atom.to_string(Module.concat(process_manager_module, State)),
-      data: process_state.state
+      source_type: Atom.to_string(process_manager_module),
+      data: process_state
     })
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -35,7 +35,6 @@ defmodule Commanded.Mixfile do
   defp deps do
     [
       {:eventstore, "~> 0.6"},
-      {:eventsourced, "~> 0.2"},
       {:ex_doc, "~> 0.14", only: :dev},
       {:markdown, github: "devinus/markdown", only: :dev},
       {:mix_test_watch, "~> 0.2", only: :dev},

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Commanded.Mixfile do
   def project do
     [
       app: :commanded,
-      version: "0.7.1",
+      version: "0.8.0",
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env),
       description: description,
@@ -21,7 +21,6 @@ defmodule Commanded.Mixfile do
       applications: [
         :logger,
         :eventstore,
-        :eventsourced,
         :poison,
         :uuid
       ],

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,6 @@
   "db_connection": {:hex, :db_connection, "1.1.0", "b2b88db6d7d12f99997b584d09fad98e560b817a20dab6a526830e339f54cdb3", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "eventsourced": {:hex, :eventsourced, "0.2.1", "eeaaa30e4bafd101e66f022c5e817fe9648196b85027b339f5f416ec991c01b1", [], []},
   "eventstore": {:hex, :eventstore, "0.6.2", "c6e8badf9e35d2f7e19d8ac41a0781bbcc22ccf87a0c473b5c2b137ace76cd33", [:mix], [{:fsm, "~> 0.2", [hex: :fsm, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.12", [hex: :postgrex, optional: false]}]},
   "ex_doc": {:hex, :ex_doc, "0.14.3", "e61cec6cf9731d7d23d254266ab06ac1decbb7651c3d1568402ec535d387b6f7", [], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},

--- a/test/aggregates/event_persistence_test.exs
+++ b/test/aggregates/event_persistence_test.exs
@@ -1,40 +1,37 @@
 defmodule Commanded.Entities.EventPersistenceTest do
   use Commanded.StorageCase
 
+  import Commanded.Enumerable, only: [pluck: 2]
+
   alias Commanded.Aggregates.{Registry,Aggregate}
 
   defmodule ExampleAggregate do
-    use EventSourced.AggregateRoot, fields: [items: [], last_index: 0]
+    defstruct [
+      items: [],
+      last_index: 0,
+    ]
 
     defmodule Commands do
-      defmodule AppendItems do
-        defstruct count: 0
-      end
+      defmodule AppendItems, do: defstruct [count: 0]
     end
 
     defmodule Events do
-      defmodule ItemAppended do
-        defstruct index: nil
-      end
+      defmodule ItemAppended, do: defstruct [index: nil]
     end
 
     alias Commands.{AppendItems}
     alias Events.{ItemAppended}
 
-    def append_items(%ExampleAggregate{state: %{last_index: last_index}} = aggregate, count) do
-      range = 1..count
-
-      aggregate = Enum.reduce(range, aggregate, fn (index, aggregate) ->
-        update(aggregate, %ItemAppended{index: last_index + index})
+    def append_items(%ExampleAggregate{last_index: last_index}, count) do
+      Enum.map(1..count, fn index ->
+        %ItemAppended{index: last_index + index}
       end)
-
-      {:ok, aggregate}
     end
 
     # state mutatators
 
-    def apply(%ExampleAggregate.State{items: items} = state, %ItemAppended{index: index}) do
-      %ExampleAggregate.State{state |
+    def apply(%ExampleAggregate{items: items} = state, %ItemAppended{index: index}) do
+      %ExampleAggregate{state |
         items: items ++ [index],
         last_index: index,
       }
@@ -76,10 +73,10 @@ defmodule Commanded.Entities.EventPersistenceTest do
     {:ok, aggregate} = Registry.open_aggregate(ExampleAggregate, aggregate_uuid)
     aggregate_state = Aggregate.aggregate_state(aggregate)
 
-    assert aggregate_state.uuid == aggregate_uuid
-    assert aggregate_state.version == 10
-    assert aggregate_state.pending_events == []
-    assert aggregate_state.state == %Commanded.Entities.EventPersistenceTest.ExampleAggregate.State{
+    # assert aggregate_state.uuid == aggregate_uuid
+    # assert aggregate_state.version == 10
+    # assert aggregate_state.pending_events == []
+    assert aggregate_state == %Commanded.Entities.EventPersistenceTest.ExampleAggregate{
       items: 1..10 |> Enum.to_list,
       last_index: 10,
     }
@@ -100,16 +97,12 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     aggregate_state = Aggregate.aggregate_state(aggregate)
 
-    assert aggregate_state.uuid == aggregate_uuid
-    assert aggregate_state.version == 201
-    assert aggregate_state.pending_events == []
-    assert aggregate_state.state == %Commanded.Entities.EventPersistenceTest.ExampleAggregate.State{
+    # assert aggregate_state.uuid == aggregate_uuid
+    # assert aggregate_state.version == 201
+    # assert aggregate_state.pending_events == []
+    assert aggregate_state == %Commanded.Entities.EventPersistenceTest.ExampleAggregate{
       items: 1..201 |> Enum.to_list,
       last_index: 201,
     }
-  end
-
-  defp pluck(enumerable, field) do
-    Enum.map(enumerable, &Map.get(&1, field))
   end
 end

--- a/test/aggregates/event_persistence_test.exs
+++ b/test/aggregates/event_persistence_test.exs
@@ -43,10 +43,7 @@ defmodule Commanded.Entities.EventPersistenceTest do
   defmodule AppendItemsHandler do
     @behaviour Commanded.Commands.Handler
 
-    def handle(%ExampleAggregate{} = aggregate, %AppendItems{count: count}) do
-      aggregate
-      |> ExampleAggregate.append_items(count)
-    end
+    def handle(%ExampleAggregate{} = aggregate, %AppendItems{count: count}), do: ExampleAggregate.append_items(aggregate, count)
   end
 
   test "should persist pending events in order applied" do
@@ -71,12 +68,10 @@ defmodule Commanded.Entities.EventPersistenceTest do
     Commanded.Helpers.Process.shutdown(aggregate)
 
     {:ok, aggregate} = Registry.open_aggregate(ExampleAggregate, aggregate_uuid)
-    aggregate_state = Aggregate.aggregate_state(aggregate)
 
-    # assert aggregate_state.uuid == aggregate_uuid
-    # assert aggregate_state.version == 10
-    # assert aggregate_state.pending_events == []
-    assert aggregate_state == %Commanded.Entities.EventPersistenceTest.ExampleAggregate{
+    assert Aggregate.aggregate_uuid(aggregate) == aggregate_uuid
+    assert Aggregate.aggregate_version(aggregate) == 10
+    assert Aggregate.aggregate_state(aggregate) == %Commanded.Entities.EventPersistenceTest.ExampleAggregate{
       items: 1..10 |> Enum.to_list,
       last_index: 10,
     }
@@ -97,9 +92,8 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     aggregate_state = Aggregate.aggregate_state(aggregate)
 
-    # assert aggregate_state.uuid == aggregate_uuid
-    # assert aggregate_state.version == 201
-    # assert aggregate_state.pending_events == []
+    assert Aggregate.aggregate_uuid(aggregate) == aggregate_uuid
+    assert Aggregate.aggregate_version(aggregate) == 201
     assert aggregate_state == %Commanded.Entities.EventPersistenceTest.ExampleAggregate{
       items: 1..201 |> Enum.to_list,
       last_index: 201,

--- a/test/commands/command_timeout_test.exs
+++ b/test/commands/command_timeout_test.exs
@@ -22,14 +22,19 @@ defmodule Commanded.Commands.CommandTimeoutTest do
 
   test "should allow timeout to be specified during command registration" do
     # handler is set to take longer than the configured timeout
-    {:error, :aggregate_execution_timeout} = TimeoutRouter.dispatch(%TimeoutCommand{sleep_in_ms: 2_000})
+    case TimeoutRouter.dispatch(%TimeoutCommand{aggregate_uuid: UUID.uuid4, sleep_in_ms: 2_000}) do
+      {:error, :aggregate_execution_failed} -> :ok
+      {:error, :aggregate_execution_failed, _reason} -> :ok
+      {:error, :aggregate_execution_timeout} -> :ok
+      _ = reply -> flunk("received an unexpected response: #{inspect reply}")
+    end
   end
 
   test "should succeed when handler completes within configured timeout" do
-    :ok = TimeoutRouter.dispatch(%TimeoutCommand{sleep_in_ms: 100})
+    :ok = TimeoutRouter.dispatch(%TimeoutCommand{aggregate_uuid: UUID.uuid4, sleep_in_ms: 100})
   end
 
   test "should succeed when timeout is overridden during dispatch" do
-    :ok = TimeoutRouter.dispatch(%TimeoutCommand{sleep_in_ms: 100}, 2_000)
+    :ok = TimeoutRouter.dispatch(%TimeoutCommand{aggregate_uuid: UUID.uuid4, sleep_in_ms: 100}, 2_000)
   end
 end

--- a/test/commands/command_timeout_test.exs
+++ b/test/commands/command_timeout_test.exs
@@ -2,20 +2,15 @@ defmodule Commanded.Commands.CommandTimeoutTest do
   use Commanded.StorageCase
   doctest Commanded.Commands.Router
 
-  defmodule StubAggregateRoot do
-    use EventSourced.AggregateRoot, fields: []
-  end
-
-  defmodule TimeoutCommand do
-    defstruct aggregate_uuid: UUID.uuid4, sleep_in_ms: nil
-  end
+  defmodule StubAggregateRoot, do: defstruct []
+  defmodule TimeoutCommand, do: defstruct [aggregate_uuid: nil, sleep_in_ms: nil]
 
   defmodule TimeoutCommandHandler do
     @behaviour Commanded.Commands.Handler
 
-    def handle(%StubAggregateRoot{} = aggregate, %TimeoutCommand{sleep_in_ms: sleep_in_ms}) do
+    def handle(%StubAggregateRoot{}, %TimeoutCommand{sleep_in_ms: sleep_in_ms}) do
       :timer.sleep(sleep_in_ms)
-      {:ok, aggregate}
+      []
     end
   end
 

--- a/test/commands/handle_command_test.exs
+++ b/test/commands/handle_command_test.exs
@@ -4,14 +4,17 @@ defmodule Commanded.Commands.HandleCommandTest do
 
   alias Commanded.ExampleDomain.{BankAccount,OpenAccountHandler}
   alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+  alias Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened
 
   test "command handler implements behaviour" do
-    {:ok, account} =
-      BankAccount.new("1")
-      |> OpenAccountHandler.handle(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
+    initial_state = %BankAccount{}
+    event = OpenAccountHandler.handle(initial_state, %OpenAccount{account_number: "ACC123", initial_balance: 1_000})
 
-    assert account.state.account_number == "ACC123"
-    assert length(account.pending_events) == 1
-    assert account.version == 1
+    assert event == %BankAccountOpened{account_number: "ACC123", initial_balance: 1_000}
+    assert BankAccount.apply(initial_state, event) == %BankAccount{
+      account_number: "ACC123",
+      balance: 1_000,
+      state: :active,
+    }
   end
 end

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -6,9 +6,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   alias Commanded.ExampleDomain.{OpenAccountHandler,DepositMoneyHandler,WithdrawMoneyHandler}
   alias Commanded.ExampleDomain.BankAccount.Commands.{OpenAccount,CloseAccount,DepositMoney,WithdrawMoney}
 
-  defmodule UnregisteredCommand do
-    defstruct aggregate_uuid: UUID.uuid4
-  end
+  defmodule UnregisteredCommand, do: defstruct [aggregate_uuid: UUID.uuid4]
 
   defmodule ExampleRouter do
     use Commanded.Commands.Router

--- a/test/event/handle_event_test.exs
+++ b/test/event/handle_event_test.exs
@@ -1,6 +1,7 @@
 defmodule Commanded.Event.HandleEventTest do
 	use Commanded.StorageCase
-	doctest Commanded.Event.Handler
+
+  import Commanded.Enumerable, only: [pluck: 2]
 
   alias Commanded.Event.AppendingEventHandler
   alias Commanded.Helpers.EventFactory
@@ -26,9 +27,7 @@ defmodule Commanded.Event.HandleEventTest do
     assert AccountBalanceHandler.current_balance == 1_050
 	end
 
-  defmodule UninterestingEvent do
-    defstruct field: nil
-  end
+  defmodule UninterestingEvent, do: defstruct [field: nil]
 
   test "should ignore uninterested events" do
     {:ok, _} = AccountBalanceHandler.start_link
@@ -81,8 +80,4 @@ defmodule Commanded.Event.HandleEventTest do
     assert AppendingEventHandler.received_events == events
     assert pluck(AppendingEventHandler.received_metadata, :event_id) == [1, 2]
 	end
-
-  defp pluck(enumerable, field) do
-    Enum.map(enumerable, &Map.get(&1, field))
-  end
 end

--- a/test/example_domain/bank_account/bank_account.ex
+++ b/test/example_domain/bank_account/bank_account.ex
@@ -1,5 +1,9 @@
 defmodule Commanded.ExampleDomain.BankAccount do
-  use EventSourced.AggregateRoot, fields: [account_number: nil, balance: 0, is_active?: false]
+  defstruct [
+    account_number: nil,
+    balance: 0,
+    state: nil,
+  ]
 
   alias Commanded.ExampleDomain.BankAccount
 
@@ -14,75 +18,64 @@ defmodule Commanded.ExampleDomain.BankAccount do
     defmodule BankAccountOpened,  do: defstruct [:account_number, :initial_balance]
     defmodule MoneyDeposited,     do: defstruct [:account_number, :transfer_uuid, :amount, :balance]
     defmodule MoneyWithdrawn,     do: defstruct [:account_number, :transfer_uuid, :amount, :balance]
+    defmodule AccountOverdrawn,   do: defstruct [:account_number, :balance]
     defmodule BankAccountClosed,  do: defstruct [:account_number]
   end
 
   alias Commands.{OpenAccount,DepositMoney,WithdrawMoney,CloseAccount}
-  alias Events.{BankAccountOpened,MoneyDeposited,MoneyWithdrawn,BankAccountClosed}
+  alias Events.{BankAccountOpened,MoneyDeposited,MoneyWithdrawn,AccountOverdrawn,BankAccountClosed}
 
-  def open_account(%BankAccount{state: %{is_active?: true}}, %OpenAccount{}), do: {:error, :account_already_open}
-  def open_account(%BankAccount{state: %{is_active?: false}} = account, %OpenAccount{account_number: account_number, initial_balance: initial_balance}) when is_number(initial_balance) and initial_balance > 0 do
-    account =
-      account
-      |> update(%BankAccountOpened{account_number: account_number, initial_balance: initial_balance})
-
-    {:ok, account}
+  def open_account(%BankAccount{state: nil} = account, %OpenAccount{account_number: account_number, initial_balance: initial_balance})
+    when is_number(initial_balance) and initial_balance > 0
+  do
+    %BankAccountOpened{account_number: account_number, initial_balance: initial_balance}
   end
 
-  def deposit(%BankAccount{} = account, %DepositMoney{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount}) when is_number(amount) and amount > 0 do
-    balance = account.state.balance + amount
+  def deposit(%BankAccount{state: :active, balance: balance}, %DepositMoney{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount})
+    when is_number(amount) and amount > 0
+  do
+    balance = balance + amount
 
-    account =
-      account
-      |> update(%MoneyDeposited{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance})
-
-    {:ok, account}
+    %MoneyDeposited{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance}
   end
 
-  def withdraw(%BankAccount{} = account, %WithdrawMoney{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount}) when is_number(amount) and amount > 0 do
-    balance = account.state.balance - amount
-
-    account =
-      account
-      |> update(%MoneyWithdrawn{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance})
-
-    {:ok, account}
+  def withdraw(%BankAccount{state: :active, balance: balance}, %WithdrawMoney{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount})
+    when is_number(amount) and amount > 0
+  do
+    case balance - amount do
+      balance when balance < 0 ->
+        [
+          %MoneyWithdrawn{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance},
+          %AccountOverdrawn{account_number: account_number, balance: balance},
+        ]
+      balance ->
+        %MoneyWithdrawn{account_number: account_number, transfer_uuid: transfer_uuid, amount: amount, balance: balance}
+    end
   end
 
-  def close_account(%BankAccount{state: %{is_active?: false}}, %OpenAccount{}), do: {:error, :account_already_closed}
-  def close_account(%BankAccount{state: %{is_active?: true}} = account, %CloseAccount{account_number: account_number}) do
-    account =
-      account
-      |> update(%BankAccountClosed{account_number: account_number})
-
-    {:ok, account}
+  def close_account(%BankAccount{state: :active} = account, %CloseAccount{account_number: account_number}) do
+    %BankAccountClosed{account_number: account_number}
   end
 
   # state mutatators
 
-  def apply(%BankAccount.State{} = state, %BankAccountOpened{} = account_opened) do
-    %BankAccount.State{state |
-      account_number: account_opened.account_number,
-      balance: account_opened.initial_balance,
-      is_active?: true,
+  def apply(%BankAccount{} = state, %BankAccountOpened{account_number: account_number, initial_balance: initial_balance}) do
+    %BankAccount{state |
+      account_number: account_number,
+      balance: initial_balance,
+      state: :active,
     }
   end
 
-  def apply(%BankAccount.State{} = state, %MoneyDeposited{} = money_deposited) do
-    %BankAccount.State{state |
-      balance: money_deposited.balance
-    }
-  end
+  def apply(%BankAccount{} = state, %MoneyDeposited{balance: balance}), do: %BankAccount{state | balance: balance}
 
-  def apply(%BankAccount.State{} = state, %MoneyWithdrawn{} = money_withdrawn) do
-    %BankAccount.State{state |
-      balance: money_withdrawn.balance
-    }
-  end
+  def apply(%BankAccount{} = state, %MoneyWithdrawn{balance: balance}), do: %BankAccount{state | balance: balance}
 
-  def apply(%BankAccount.State{} = state, %BankAccountClosed{}) do
-    %BankAccount.State{state |
-      is_active?: false,
+  def apply(%BankAccount{} = state, %AccountOverdrawn{}), do: state
+
+  def apply(%BankAccount{} = state, %BankAccountClosed{}) do
+    %BankAccount{state |
+      state: :closed,
     }
   end
 end

--- a/test/example_domain/bank_account/bank_account.ex
+++ b/test/example_domain/bank_account/bank_account.ex
@@ -25,7 +25,7 @@ defmodule Commanded.ExampleDomain.BankAccount do
   alias Commands.{OpenAccount,DepositMoney,WithdrawMoney,CloseAccount}
   alias Events.{BankAccountOpened,MoneyDeposited,MoneyWithdrawn,AccountOverdrawn,BankAccountClosed}
 
-  def open_account(%BankAccount{state: nil} = account, %OpenAccount{account_number: account_number, initial_balance: initial_balance})
+  def open_account(%BankAccount{state: nil}, %OpenAccount{account_number: account_number, initial_balance: initial_balance})
     when is_number(initial_balance) and initial_balance > 0
   do
     %BankAccountOpened{account_number: account_number, initial_balance: initial_balance}
@@ -53,7 +53,7 @@ defmodule Commanded.ExampleDomain.BankAccount do
     end
   end
 
-  def close_account(%BankAccount{state: :active} = account, %CloseAccount{account_number: account_number}) do
+  def close_account(%BankAccount{state: :active}, %CloseAccount{account_number: account_number}) do
     %BankAccountClosed{account_number: account_number}
   end
 

--- a/test/example_domain/money_transfer/money_transfer.ex
+++ b/test/example_domain/money_transfer/money_transfer.ex
@@ -4,6 +4,7 @@ defmodule Commanded.ExampleDomain.MoneyTransfer do
     debit_account: nil,
     credit_account: nil,
     amount: 0,
+    state: nil,
   ]
 
   alias Commanded.ExampleDomain.MoneyTransfer
@@ -19,7 +20,7 @@ defmodule Commanded.ExampleDomain.MoneyTransfer do
   alias Commands.{TransferMoney}
   alias Events.{MoneyTransferRequested}
 
-  def transfer_money(%MoneyTransfer{} = money_transfer, %TransferMoney{transfer_uuid: transfer_uuid, debit_account: debit_account, credit_account: credit_account, amount: amount})
+  def transfer_money(%MoneyTransfer{state: nil}, %TransferMoney{transfer_uuid: transfer_uuid, debit_account: debit_account, credit_account: credit_account, amount: amount})
     when amount > 0
   do
     %MoneyTransferRequested{transfer_uuid: transfer_uuid, debit_account: debit_account, credit_account: credit_account, amount: amount}
@@ -32,7 +33,8 @@ defmodule Commanded.ExampleDomain.MoneyTransfer do
       transfer_uuid: transfer_requested.transfer_uuid,
       debit_account: transfer_requested.debit_account,
       credit_account: transfer_requested.credit_account,
-      amount: transfer_requested.amount
+      amount: transfer_requested.amount,
+      state: :requested,
     }
   end
 end

--- a/test/example_domain/money_transfer/money_transfer.ex
+++ b/test/example_domain/money_transfer/money_transfer.ex
@@ -1,38 +1,37 @@
 defmodule Commanded.ExampleDomain.MoneyTransfer do
-  use EventSourced.AggregateRoot, fields: [transfer_uuid: nil, source_account: nil, target_account: nil, amount: 0, reversed?: false]
+  defstruct [
+    transfer_uuid: nil,
+    debit_account: nil,
+    credit_account: nil,
+    amount: 0,
+  ]
 
   alias Commanded.ExampleDomain.MoneyTransfer
 
   defmodule Commands do
-    defmodule TransferMoney do
-      defstruct transfer_uuid: UUID.uuid4, source_account: nil, target_account: nil, amount: nil
-    end
+    defmodule TransferMoney, do: defstruct [transfer_uuid: nil, debit_account: nil, credit_account: nil, amount: nil]
   end
 
   defmodule Events do
-    defmodule MoneyTransferRequested do
-      defstruct transfer_uuid: nil, source_account: nil, target_account: nil, amount: nil
-    end
+    defmodule MoneyTransferRequested, do: defstruct [transfer_uuid: nil, debit_account: nil, credit_account: nil, amount: nil]
   end
 
   alias Commands.{TransferMoney}
   alias Events.{MoneyTransferRequested}
 
-  def transfer_money(%MoneyTransfer{} = money_transfer, %TransferMoney{transfer_uuid: transfer_uuid, source_account: source_account, target_account: target_account, amount: amount}) when amount > 0 do
-    money_transfer =
-      money_transfer
-      |> update(%MoneyTransferRequested{transfer_uuid: transfer_uuid, source_account: source_account, target_account: target_account, amount: amount})
-
-    {:ok, money_transfer}
+  def transfer_money(%MoneyTransfer{} = money_transfer, %TransferMoney{transfer_uuid: transfer_uuid, debit_account: debit_account, credit_account: credit_account, amount: amount})
+    when amount > 0
+  do
+    %MoneyTransferRequested{transfer_uuid: transfer_uuid, debit_account: debit_account, credit_account: credit_account, amount: amount}
   end
 
   # state mutatators
 
-  def apply(%MoneyTransfer.State{} = state, %MoneyTransferRequested{} = transfer_requested) do
-    %MoneyTransfer.State{state |
+  def apply(%MoneyTransfer{} = state, %MoneyTransferRequested{} = transfer_requested) do
+    %MoneyTransfer{state |
       transfer_uuid: transfer_requested.transfer_uuid,
-      source_account: transfer_requested.source_account,
-      target_account: transfer_requested.target_account,
+      debit_account: transfer_requested.debit_account,
+      credit_account: transfer_requested.credit_account,
       amount: transfer_requested.amount
     }
   end

--- a/test/example_domain/money_transfer/transfer_money_process_manager.ex
+++ b/test/example_domain/money_transfer/transfer_money_process_manager.ex
@@ -1,7 +1,7 @@
 defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
   use Commanded.ProcessManagers.ProcessManager, fields: [
-    source_account: nil,
-    target_account: nil,
+    debit_account: nil,
+    credit_account: nil,
     amount: nil,
     status: nil
   ]
@@ -16,10 +16,10 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
   def interested?(%MoneyDeposited{transfer_uuid: transfer_uuid}), do: {:continue, transfer_uuid}
   def interested?(_event), do: false
 
-  def handle(%TransferMoneyProcessManager{process_uuid: transfer_uuid} = transfer, %MoneyTransferRequested{source_account: source_account, amount: amount} = money_transfer_requested) do
+  def handle(%TransferMoneyProcessManager{process_uuid: transfer_uuid} = transfer, %MoneyTransferRequested{debit_account: debit_account, amount: amount} = money_transfer_requested) do
     transfer =
       transfer
-      |> dispatch(%WithdrawMoney{account_number: source_account, transfer_uuid: transfer_uuid, amount: amount})
+      |> dispatch(%WithdrawMoney{account_number: debit_account, transfer_uuid: transfer_uuid, amount: amount})
       |> update(money_transfer_requested)
 
     {:ok, transfer}
@@ -28,7 +28,7 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
   def handle(%TransferMoneyProcessManager{process_uuid: transfer_uuid, state: state} = transfer, %MoneyWithdrawn{} = money_withdrawn) do
     transfer =
       transfer
-      |> dispatch(%DepositMoney{account_number: state.target_account, transfer_uuid: transfer_uuid, amount: state.amount})
+      |> dispatch(%DepositMoney{account_number: state.credit_account, transfer_uuid: transfer_uuid, amount: state.amount})
       |> update(money_withdrawn)
 
     {:ok, transfer}
@@ -43,18 +43,18 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
 
   ## state mutators
 
-  def apply(%TransferMoneyProcessManager.State{} = transfer, %MoneyTransferRequested{source_account: source_account, target_account: target_account, amount: amount}) do
+  def apply(%TransferMoneyProcessManager.State{} = transfer, %MoneyTransferRequested{debit_account: debit_account, credit_account: credit_account, amount: amount}) do
     %TransferMoneyProcessManager.State{transfer |
-      source_account: source_account,
-      target_account: target_account,
+      debit_account: debit_account,
+      credit_account: credit_account,
       amount: amount,
-      status: :withdraw_money_from_source_account
+      status: :withdraw_money_from_debit_account
     }
   end
 
   def apply(%TransferMoneyProcessManager.State{} = transfer, %MoneyWithdrawn{}) do
     %TransferMoneyProcessManager.State{transfer |
-      status: :deposit_money_in_target_account
+      status: :deposit_money_in_credit_account
     }
   end
 

--- a/test/example_domain/money_transfer/transfer_money_process_manager.ex
+++ b/test/example_domain/money_transfer/transfer_money_process_manager.ex
@@ -1,5 +1,8 @@
 defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
-  use Commanded.ProcessManagers.ProcessManager, fields: [
+  @behaviour Commanded.ProcessManagers.ProcessManager
+
+  defstruct [
+    transfer_uuid: nil,
     debit_account: nil,
     credit_account: nil,
     amount: nil,
@@ -16,35 +19,21 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
   def interested?(%MoneyDeposited{transfer_uuid: transfer_uuid}), do: {:continue, transfer_uuid}
   def interested?(_event), do: false
 
-  def handle(%TransferMoneyProcessManager{process_uuid: transfer_uuid} = transfer, %MoneyTransferRequested{debit_account: debit_account, amount: amount} = money_transfer_requested) do
-    transfer =
-      transfer
-      |> dispatch(%WithdrawMoney{account_number: debit_account, transfer_uuid: transfer_uuid, amount: amount})
-      |> update(money_transfer_requested)
-
-    {:ok, transfer}
+  def handle(%TransferMoneyProcessManager{}, %MoneyTransferRequested{transfer_uuid: transfer_uuid, debit_account: debit_account, amount: amount}) do
+    %WithdrawMoney{account_number: debit_account, transfer_uuid: transfer_uuid, amount: amount}
   end
 
-  def handle(%TransferMoneyProcessManager{process_uuid: transfer_uuid, state: state} = transfer, %MoneyWithdrawn{} = money_withdrawn) do
-    transfer =
-      transfer
-      |> dispatch(%DepositMoney{account_number: state.credit_account, transfer_uuid: transfer_uuid, amount: state.amount})
-      |> update(money_withdrawn)
-
-    {:ok, transfer}
+  def handle(%TransferMoneyProcessManager{transfer_uuid: transfer_uuid, credit_account: credit_account, amount: amount}, %MoneyWithdrawn{}) do
+    %DepositMoney{account_number: credit_account, transfer_uuid: transfer_uuid, amount: amount}
   end
 
-  def handle(%TransferMoneyProcessManager{} = transfer, %MoneyDeposited{} = money_deposited) do
-    {:ok, update(transfer, money_deposited)}
-  end
-
-  # ignore any other events
-  def handle(transfer, _event), do: {:ok, transfer}
+  def handle(%TransferMoneyProcessManager{}, %MoneyDeposited{}), do: []
 
   ## state mutators
 
-  def apply(%TransferMoneyProcessManager.State{} = transfer, %MoneyTransferRequested{debit_account: debit_account, credit_account: credit_account, amount: amount}) do
-    %TransferMoneyProcessManager.State{transfer |
+  def apply(%TransferMoneyProcessManager{} = transfer, %MoneyTransferRequested{transfer_uuid: transfer_uuid, debit_account: debit_account, credit_account: credit_account, amount: amount}) do
+    %TransferMoneyProcessManager{transfer |
+      transfer_uuid: transfer_uuid,
       debit_account: debit_account,
       credit_account: credit_account,
       amount: amount,
@@ -52,14 +41,14 @@ defmodule Commanded.ExampleDomain.TransferMoneyProcessManager do
     }
   end
 
-  def apply(%TransferMoneyProcessManager.State{} = transfer, %MoneyWithdrawn{}) do
-    %TransferMoneyProcessManager.State{transfer |
+  def apply(%TransferMoneyProcessManager{} = transfer, %MoneyWithdrawn{}) do
+    %TransferMoneyProcessManager{transfer |
       status: :deposit_money_in_credit_account
     }
   end
 
-  def apply(%TransferMoneyProcessManager.State{} = transfer, %MoneyDeposited{}) do
-    %TransferMoneyProcessManager.State{transfer |
+  def apply(%TransferMoneyProcessManager{} = transfer, %MoneyDeposited{}) do
+    %TransferMoneyProcessManager{transfer |
       status: :transfer_complete
     }
   end

--- a/test/helpers/commands/commands.ex
+++ b/test/helpers/commands/commands.ex
@@ -1,6 +1,6 @@
 defmodule Commanded.Helpers.Commands do
   defmodule IncrementCount do
-    defstruct aggregate_uuid: nil, by: 1
+    defstruct [aggregate_uuid: nil, by: 1]
   end
 
   defmodule Fail do
@@ -24,14 +24,16 @@ defmodule Commanded.Helpers.Commands do
   end
 
   defmodule CounterAggregateRoot do
-    use EventSourced.AggregateRoot, fields: [count: 0]
+    defstruct [count: 0]
 
-    def increment(%CounterAggregateRoot{state: %{count: count}} = counter, increment_by) when is_integer(increment_by) do
-      {:ok, update(counter, %CountIncremented{count: count + increment_by})}
+    def increment(%CounterAggregateRoot{count: count} = counter, increment_by)
+      when is_integer(increment_by)
+    do
+      %CountIncremented{count: count + increment_by}
     end
 
-    def apply(%CounterAggregateRoot.State{} = state, %CountIncremented{count: count}) do
-      %CounterAggregateRoot.State{state | count: count}
+    def apply(%CounterAggregateRoot{} = state, %CountIncremented{count: count}) do
+      %CounterAggregateRoot{state | count: count}
     end
   end
 
@@ -52,11 +54,11 @@ defmodule Commanded.Helpers.Commands do
 
     def handle(%CounterAggregateRoot{} = aggregate, %Timeout{}) do
       :timer.sleep 1_000
-      {:ok, aggregate}
+      []
     end
 
     def handle(%CounterAggregateRoot{} = aggregate, %Validate{}) do
-      {:ok, aggregate}
+      []
     end
   end
 end

--- a/test/helpers/commands/commands.ex
+++ b/test/helpers/commands/commands.ex
@@ -8,11 +8,11 @@ defmodule Commanded.Helpers.Commands do
   defmodule Timeout, do: defstruct [:aggregate_uuid]
   defmodule Validate, do: defstruct [:aggregate_uuid, :valid?]
   defmodule CountIncremented, do: defstruct [:count]
-  
+
   defmodule CounterAggregateRoot do
     defstruct [count: 0]
 
-    def increment(%CounterAggregateRoot{count: count} = counter, increment_by)
+    def increment(%CounterAggregateRoot{count: count}, increment_by)
       when is_integer(increment_by)
     do
       %CountIncremented{count: count + increment_by}
@@ -38,12 +38,12 @@ defmodule Commanded.Helpers.Commands do
       raise "failed"
     end
 
-    def handle(%CounterAggregateRoot{} = aggregate, %Timeout{}) do
+    def handle(%CounterAggregateRoot{}, %Timeout{}) do
       :timer.sleep 1_000
       []
     end
 
-    def handle(%CounterAggregateRoot{} = aggregate, %Validate{}) do
+    def handle(%CounterAggregateRoot{}, %Validate{}) do
       []
     end
   end

--- a/test/helpers/commands/commands.ex
+++ b/test/helpers/commands/commands.ex
@@ -3,26 +3,12 @@ defmodule Commanded.Helpers.Commands do
     defstruct [aggregate_uuid: nil, by: 1]
   end
 
-  defmodule Fail do
-    defstruct [:aggregate_uuid]
-  end
-
-  defmodule RaiseError do
-    defstruct [:aggregate_uuid]
-  end
-
-  defmodule Timeout do
-    defstruct [:aggregate_uuid]
-  end
-
-  defmodule Validate do
-    defstruct [:aggregate_uuid, :valid?]
-  end
-
-  defmodule CountIncremented do
-    defstruct [:count]
-  end
-
+  defmodule Fail, do: defstruct [:aggregate_uuid]
+  defmodule RaiseError, do: defstruct [:aggregate_uuid]
+  defmodule Timeout, do: defstruct [:aggregate_uuid]
+  defmodule Validate, do: defstruct [:aggregate_uuid, :valid?]
+  defmodule CountIncremented, do: defstruct [:count]
+  
   defmodule CounterAggregateRoot do
     defstruct [count: 0]
 

--- a/test/middleware/middleware_test.exs
+++ b/test/middleware/middleware_test.exs
@@ -90,7 +90,10 @@ defmodule Commanded.Commands.Middleware.MiddlewareTest do
     {:ok, _} = CommandAuditMiddleware.start_link
 
     # force command handling to timeout so the aggregate process is terminated
-    {:error, :aggregate_execution_timeout} = Router.dispatch(%Timeout{aggregate_uuid: UUID.uuid4}, 50)
+    :ok = case Router.dispatch(%Timeout{aggregate_uuid: UUID.uuid4}, 50) do
+      {:error, :aggregate_execution_timeout} -> :ok
+      {:error, :aggregate_execution_failed} -> :ok
+    end
 
     {dispatched, succeeded, failed} = CommandAuditMiddleware.count_commands
 

--- a/test/process_managers/process_manager_instance_test.exs
+++ b/test/process_managers/process_manager_instance_test.exs
@@ -33,8 +33,8 @@ defmodule Commanded.ProcessManager.ProcessManagerInstanceTest do
       event_id: 1,
       data: %MoneyTransferRequested{
         transfer_uuid: process_uuid,
-        source_account: account1_uuid,
-        target_account: account2_uuid,
+        debit_account: account1_uuid,
+        credit_account: account2_uuid,
         amount: 100
       },
     }

--- a/test/process_managers/process_manager_instance_test.exs
+++ b/test/process_managers/process_manager_instance_test.exs
@@ -8,31 +8,29 @@ defmodule Commanded.ProcessManager.ProcessManagerInstanceTest do
   alias Commanded.ExampleDomain.BankAccount.Commands.WithdrawMoney
   alias Commanded.ExampleDomain.TransferMoneyProcessManager
 
-  defmodule OpenAccountHandler do
+  defmodule NullHandler do
     @behaviour Commanded.Commands.Handler
 
-    def handle(%BankAccount{} = aggregate, %WithdrawMoney{}) do
-      {:ok, aggregate}
-    end
+    def handle(_aggregate, _command), do: []
   end
 
   defmodule Router do
     use Commanded.Commands.Router
 
-    dispatch WithdrawMoney, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
+    dispatch WithdrawMoney, to: NullHandler, aggregate: BankAccount, identity: :account_number
   end
 
   test "process manager handles an event" do
-    process_uuid = UUID.uuid4
+    transfer_uuid = UUID.uuid4
     account1_uuid = UUID.uuid4
     account2_uuid = UUID.uuid4
 
-    {:ok, process_manager} = ProcessManagerInstance.start_link(Router, "TransferMoneyProcessManager", TransferMoneyProcessManager, process_uuid)
+    {:ok, process_manager} = ProcessManagerInstance.start_link(Router, "TransferMoneyProcessManager", TransferMoneyProcessManager, transfer_uuid)
 
     event = %EventStore.RecordedEvent{
       event_id: 1,
       data: %MoneyTransferRequested{
-        transfer_uuid: process_uuid,
+        transfer_uuid: transfer_uuid,
         debit_account: account1_uuid,
         credit_account: account2_uuid,
         amount: 100

--- a/test/process_managers/process_manager_routing_test.exs
+++ b/test/process_managers/process_manager_routing_test.exs
@@ -33,11 +33,11 @@ defmodule Commanded.ProcessManager.ProcessManagerRoutingTest do
     :ok = BankRouter.dispatch(%OpenAccount{account_number: account_number2, initial_balance:  500})
 
     # transfer funds between account 1 and account 2
-    :ok = BankRouter.dispatch(%TransferMoney{source_account: account_number1, target_account: account_number2, amount: 100})
+    :ok = BankRouter.dispatch(%TransferMoney{transfer_uuid: UUID.uuid4, debit_account: account_number1, credit_account: account_number2, amount: 100})
 
     assert_receive_event MoneyTransferRequested, fn event ->
-      assert event.source_account == account_number1
-      assert event.target_account == account_number2
+      assert event.debit_account == account_number1
+      assert event.credit_account == account_number2
       assert event.amount == 100
     end
 

--- a/test/process_managers/process_router_process_pending_events_test.exs
+++ b/test/process_managers/process_router_process_pending_events_test.exs
@@ -7,80 +7,62 @@ defmodule Commanded.ProcessManager.ProcessRouterProcessPendingEventsTest do
   import Commanded.Enumerable
 
   defmodule ExampleAggregate do
-    use EventSourced.AggregateRoot, fields: [
+    defstruct [
+      uuid: nil,
       state: nil,
       items: [],
     ]
 
     defmodule Commands do
-      defmodule Start do
-        defstruct [:aggregate_uuid]
-      end
-
-      defmodule Publish do
-        defstruct [:aggregate_uuid, :interesting, :uninteresting]
-      end
-
-      defmodule Stop do
-        defstruct [:aggregate_uuid]
-      end
+      defmodule Start, do: defstruct [:aggregate_uuid]
+      defmodule Publish, do: defstruct [:aggregate_uuid, :interesting, :uninteresting]
+      defmodule Stop, do: defstruct [:aggregate_uuid]
     end
 
     defmodule Events do
-      defmodule Started do
-        defstruct [:aggregate_uuid]
-      end
-
-      defmodule Interested do
-        defstruct [:aggregate_uuid, :index]
-      end
-
-      defmodule Uninterested do
-        defstruct [:aggregate_uuid, :index]
-      end
-
-      defmodule Stopped do
-        defstruct [:aggregate_uuid]
-      end
+      defmodule Started, do: defstruct [:aggregate_uuid]
+      defmodule Interested, do: defstruct [:aggregate_uuid, :index]
+      defmodule Uninterested, do: defstruct [:aggregate_uuid, :index]
+      defmodule Stopped, do: defstruct [:aggregate_uuid]
     end
 
-    def start(%ExampleAggregate{uuid: aggregate_uuid} = aggregate) do
-      {:ok, update(aggregate, %Events.Started{aggregate_uuid: aggregate_uuid})}
+    def start(%ExampleAggregate{}, aggregate_uuid) do
+      %Events.Started{aggregate_uuid: aggregate_uuid}
     end
 
-    def publish(%ExampleAggregate{} = aggregate, interesting, uninteresting) do
-      aggregate =
-        aggregate
-        |> publish_interesting(interesting, 1)
-        |> publish_uninteresting(uninteresting, 1)
-
-      {:ok, aggregate}
+    def publish(%ExampleAggregate{uuid: aggregate_uuid}, interesting, uninteresting) do
+      Enum.concat(
+        publish_interesting(aggregate_uuid, interesting, 1),
+        publish_uninteresting(aggregate_uuid, uninteresting, 1)
+      )
     end
 
-    def stop(%ExampleAggregate{uuid: aggregate_uuid} = aggregate) do
-      {:ok, update(aggregate, %Events.Stopped{aggregate_uuid: aggregate_uuid})}
+    def stop(%ExampleAggregate{uuid: aggregate_uuid}) do
+      %Events.Stopped{aggregate_uuid: aggregate_uuid}
     end
 
-    defp publish_interesting(aggregate, 0, _index), do: aggregate
-    defp publish_interesting(%ExampleAggregate{uuid: aggregate_uuid} = aggregate, interesting, index) do
-      aggregate
-        |> update(%Events.Interested{aggregate_uuid: aggregate_uuid, index: index})
-        |> publish_interesting(interesting - 1, index + 1)
+    defp publish_interesting(_aggregate_uuid, 0, _index), do: []
+    defp publish_interesting(aggregate_uuid, interesting, index) do
+      [
+        %Events.Interested{aggregate_uuid: aggregate_uuid, index: index},
+        publish_interesting(aggregate_uuid, interesting - 1, index + 1),
+      ]
     end
 
-    defp publish_uninteresting(aggregate, 0, _index), do: aggregate
-    defp publish_uninteresting(%ExampleAggregate{uuid: aggregate_uuid} = aggregate, interesting, index) do
-      aggregate
-        |> update(%Events.Uninterested{aggregate_uuid: aggregate_uuid, index: index})
-        |> publish_uninteresting(interesting - 1, index + 1)
+    defp publish_uninteresting(_aggregate_uuid, 0, _index), do: []
+    defp publish_uninteresting(aggregate_uuid, interesting, index) do
+      [
+        %Events.Uninterested{aggregate_uuid: aggregate_uuid, index: index},
+        publish_uninteresting(aggregate_uuid, interesting - 1, index + 1),
+      ]
     end
 
     # state mutatators
 
-    def apply(%ExampleAggregate.State{} = state, %Events.Started{}), do: %ExampleAggregate.State{state | state: :started}
-    def apply(%ExampleAggregate.State{items: items} = state, %Events.Interested{index: index}), do: %ExampleAggregate.State{state | items: items ++ [index]}
-    def apply(%ExampleAggregate.State{} = state, %Events.Uninterested{}), do: state
-    def apply(%ExampleAggregate.State{} = state, %Events.Stopped{}), do: %ExampleAggregate.State{state | state: :stopped}
+    def apply(%ExampleAggregate{} = state, %Events.Started{aggregate_uuid: aggregate_uuid}), do: %ExampleAggregate{state | uuid: aggregate_uuid, state: :started}
+    def apply(%ExampleAggregate{items: items} = state, %Events.Interested{index: index}), do: %ExampleAggregate{state | items: items ++ [index]}
+    def apply(%ExampleAggregate{} = state, %Events.Uninterested{}), do: state
+    def apply(%ExampleAggregate{} = state, %Events.Stopped{}), do: %ExampleAggregate{state | state: :stopped}
   end
 
   alias ExampleAggregate.Commands.{Start,Publish,Stop}
@@ -89,7 +71,7 @@ defmodule Commanded.ProcessManager.ProcessRouterProcessPendingEventsTest do
   defmodule ExampleCommandHandler do
     @behaviour Commanded.Commands.Handler
 
-    def handle(%ExampleAggregate{} = aggregate, %Start{}), do: ExampleAggregate.start(aggregate)
+    def handle(%ExampleAggregate{} = aggregate, %Start{aggregate_uuid: aggregate_uuid}), do: ExampleAggregate.start(aggregate, aggregate_uuid)
     def handle(%ExampleAggregate{} = aggregate, %Publish{interesting: interesting, uninteresting: uninteresting}), do: ExampleAggregate.publish(aggregate, interesting, uninteresting)
     def handle(%ExampleAggregate{} = aggregate, %Stop{}), do: ExampleAggregate.stop(aggregate)
   end

--- a/test/process_managers/resume_process_manager_test.exs
+++ b/test/process_managers/resume_process_manager_test.exs
@@ -62,7 +62,9 @@ defmodule Commanded.ProcessManager.ResumeProcessManagerTest do
   end
 
   defmodule ExampleProcessManager do
-    use Commanded.ProcessManagers.ProcessManager, fields: [
+    @behaviour Commanded.ProcessManagers.ProcessManager
+
+    defstruct [
       status_history: []
     ]
 
@@ -72,24 +74,19 @@ defmodule Commanded.ProcessManager.ResumeProcessManagerTest do
     def interested?(%ProcessResumed{process_uuid: process_uuid}), do: {:continue, process_uuid}
     def interested?(_event), do: false
 
-    def handle(%ExampleProcessManager{} = process, %ProcessStarted{} = process_started) do
-      {:ok, update(process, process_started)}
-    end
-
-    def handle(%ExampleProcessManager{} = process, %ProcessResumed{} = process_resumed) do
-      {:ok, update(process, process_resumed)}
-    end
+    def handle(%ExampleProcessManager{}, %ProcessStarted{}), do: []
+    def handle(%ExampleProcessManager{}, %ProcessResumed{}), do: []
 
     ## state mutators
 
-    def apply(%ExampleProcessManager.State{status_history: status_history} = process, %ProcessStarted{status: status}) do
-      %ExampleProcessManager.State{process |
+    def apply(%ExampleProcessManager{status_history: status_history} = process, %ProcessStarted{status: status}) do
+      %ExampleProcessManager{process |
         status_history: status_history ++ [status]
       }
     end
 
-    def apply(%ExampleProcessManager.State{status_history: status_history} = process, %ProcessResumed{status: status}) do
-      %ExampleProcessManager.State{process |
+    def apply(%ExampleProcessManager{status_history: status_history} = process, %ProcessResumed{status: status}) do
+      %ExampleProcessManager{process |
         status_history: status_history ++ [status]
       }
     end

--- a/test/process_managers/resume_process_manager_test.exs
+++ b/test/process_managers/resume_process_manager_test.exs
@@ -8,60 +8,33 @@ defmodule Commanded.ProcessManager.ResumeProcessManagerTest do
   import Commanded.Assertions.EventAssertions
 
   defmodule ExampleAggregate do
-    use EventSourced.AggregateRoot, fields: [status: nil]
+    defstruct [status: nil]
 
     defmodule Commands do
-      defmodule StartProcess do
-        defstruct process_uuid: UUID.uuid4, status: nil
-      end
-
-      defmodule ResumeProcess do
-        defstruct process_uuid: UUID.uuid4, status: nil
-      end
+      defmodule StartProcess, do: defstruct [process_uuid: nil, status: nil]
+      defmodule ResumeProcess, do: defstruct [process_uuid: nil, status: nil]
     end
 
     defmodule Events do
-      defmodule ProcessStarted do
-        defstruct process_uuid: nil, status: nil
-      end
-
-      defmodule ProcessResumed do
-        defstruct process_uuid: nil, status: nil
-      end
+      defmodule ProcessStarted, do: defstruct [process_uuid: nil, status: nil]
+      defmodule ProcessResumed, do: defstruct [process_uuid: nil, status: nil]
     end
 
     alias Commands.{StartProcess,ResumeProcess}
     alias Events.{ProcessStarted,ProcessResumed}
 
-    def start_process(%ExampleAggregate{} = aggregate, %StartProcess{process_uuid: process_uuid, status: status}) do
-      aggregate =
-        aggregate
-        |> update(%ProcessStarted{process_uuid: process_uuid, status: status})
-
-      {:ok, aggregate}
+    def start_process(%ExampleAggregate{}, %StartProcess{process_uuid: process_uuid, status: status}) do
+      %ProcessStarted{process_uuid: process_uuid, status: status}
     end
 
-    def resume_process(%ExampleAggregate{} = aggregate, %ResumeProcess{process_uuid: process_uuid, status: status}) do
-      aggregate =
-        aggregate
-        |> update(%ProcessResumed{process_uuid: process_uuid, status: status})
-
-      {:ok, aggregate}
+    def resume_process(%ExampleAggregate{}, %ResumeProcess{process_uuid: process_uuid, status: status}) do
+      %ProcessResumed{process_uuid: process_uuid, status: status}
     end
 
     # state mutatators
 
-    def apply(%ExampleAggregate.State{} = state, %ProcessStarted{status: status}) do
-      %ExampleAggregate.State{state |
-        status: status
-      }
-    end
-
-    def apply(%ExampleAggregate.State{} = state, %ProcessResumed{status: status}) do
-      %ExampleAggregate.State{state |
-        status: status
-      }
-    end
+    def apply(%ExampleAggregate{} = state, %ProcessStarted{status: status}), do: %ExampleAggregate{state | status: status}
+    def apply(%ExampleAggregate{} = state, %ProcessResumed{status: status}), do: %ExampleAggregate{state | status: status}
   end
 
   alias ExampleAggregate.Commands.{StartProcess,ResumeProcess}


### PR DESCRIPTION
Drop `eventsourced` dependency.

Aggregate roots and process managers are now implemented using standard Elixir modules and functions, and structs for state. No external dependency requirements.

Aggregate root command functions receive its state and the command, returning any resultant domain events.

**Example aggregate root**

```elixir
defmodule BankAccount do
  defstruct [account_number: nil, balance: nil]

  # public command API

  def open_account(%BankAccount{} = account, account_number, initial_balance)
    when initial_balance > 0
  do
    %BankAccountOpened{account_number: account_number, initial_balance: initial_balance}
  end

  def open_account(%BankAccount{} = account, account_number, initial_balance)
    when initial_balance <= 0
  do
    {:error, :initial_balance_must_be_above_zero}
  end

  # state mutators

  def apply(%BankAccount{} = account, %BankAccountOpened{account_number: account_number, initial_balance: initial_balance}) do
    %BankAccount{account |
      account_number: account_number,
      balance: initial_balance
    }
  end
end
```
