### PR TITLE
Command handlers should be optional by default 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v0.8.1
+
+### Enhancements
+
+- Command handlers should be optional by default ([#30](https://github.com/slashdotdash/commanded/issues/30)).
+
+## v0.8.0
+
+### Enhancements
+
+- Simplify aggregate roots and process managers ([#31](https://github.com/slashdotdash/commanded/issues/31)).
+
 ## v0.7.1
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ end
 
 ### Command dispatch and routing
 
-You create a router to handle registration of each command to its associated handler. Configure each command by mapping it to a handler and aggregate root.
+You must create a router to register each command with its associated handler.
 
 ```elixir
 defmodule BankRouter do
@@ -147,6 +147,18 @@ defmodule BankRouter do
   dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount, identity: :account_number
 end
 ```
+
+It is also possible to route a command directly to an aggregate root. Without requiring an intermediate command handler.
+
+```elixir
+defmodule BankRouter do
+  use Commanded.Commands.Router
+
+  dispatch OpenAccount, to: BankAccount, identity: :account_number
+end
+```
+
+The aggregate root must implement an `execute/2` function that receives the aggregate's state and the command to execute.
 
 You can then dispatch a command using the router.
 

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -1,4 +1,33 @@
 defmodule Commanded.Commands.Router do
+  @moduledoc """
+  Command routing macro to allow configuration of each command to its command handler.
+
+  ## Example
+
+      defmodule BankRouter do
+        use Commanded.Commands.Router
+
+        dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
+      end
+
+      :ok = BankRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
+
+  The command handler module must implement a `handle/2` function that receives the aggregate's state and the command to execute.
+  It should delegate the command to the aggregate.
+
+  It is also possible to route a command directly to an aggregate root. Without requiring an intermediate command handler.
+
+  ## Example
+
+      defmodule BankRouter do
+        use Commanded.Commands.Router
+
+        dispatch OpenAccount, to: BankAccount, identity: :account_number
+      end
+
+  The aggregate root must implement an `execute/2` function that receives the aggregate's state and the command to execute.
+
+  """
   defmacro __using__(_) do
     quote do
       require Logger
@@ -6,8 +35,10 @@ defmodule Commanded.Commands.Router do
       @before_compile unquote(__MODULE__)
       @registered_commands []
       @registered_middleware []
+      @default_dispatch_timeout 5_000
     end
   end
+
 
   @doc """
   Include the given middleware module to be called before and after success or failure of each command dispatch
@@ -33,16 +64,41 @@ defmodule Commanded.Commands.Router do
     end)
   end
 
+  # dispatch directly to the aggregate root
+  defmacro dispatch(command_module, to: aggregate, identity: identity) do
+    quote do
+      register(unquote(command_module), to: unquote(aggregate), function: :execute, aggregate: unquote(aggregate), identity: unquote(identity), timeout: @default_dispatch_timeout)
+    end
+  end
+
+  # dispatch directly to the aggregate root
+  defmacro dispatch(command_module, to: aggregate, identity: identity, timeout: timeout) do
+    quote do
+      register(unquote(command_module), to: unquote(aggregate), function: :execute, aggregate: unquote(aggregate), identity: unquote(identity), timeout: unquote(timeout))
+    end
+  end
+
   defmacro dispatch(command_module, to: handler, aggregate: aggregate, identity: identity) do
     quote do
-      dispatch(unquote(command_module), to: unquote(handler), aggregate: unquote(aggregate), identity: unquote(identity), timeout: 5_000)
+      register(unquote(command_module), to: unquote(handler), function: :handle, aggregate: unquote(aggregate), identity: unquote(identity), timeout: @default_dispatch_timeout)
     end
   end
 
   defmacro dispatch(command_module, to: handler, aggregate: aggregate, identity: identity, timeout: timeout) do
     quote do
+      register(unquote(command_module), to: unquote(handler), function: :handle, aggregate: unquote(aggregate), identity: unquote(identity), timeout: unquote(timeout))
+    end
+  end
+
+  defmacro register(command_module, to: handler, function: function, aggregate: aggregate, identity: identity, timeout: timeout) do
+    quote do
       if Enum.member?(@registered_commands, unquote(command_module)) do
-        raise "duplicate command registration for: #{unquote(command_module)}"
+        raise "duplicate command registration for: #{inspect unquote(command_module)}"
+      end
+
+      handler_functions = unquote(handler).__info__(:functions)
+      unless Keyword.get(handler_functions, unquote(function)) == 2 do
+        raise "command handler #{inspect unquote(handler)} does not define a function: #{unquote(function)}/2"
       end
 
       @registered_commands [unquote(command_module) | @registered_commands]
@@ -55,14 +111,7 @@ defmodule Commanded.Commands.Router do
       @spec dispatch(command :: struct) :: :ok | {:error, reason :: term}
       def dispatch(command)
       def dispatch(%unquote(command_module){} = command) do
-        Commanded.Commands.Dispatcher.dispatch(%Commanded.Commands.Dispatcher.Payload{
-          command: command,
-          handler_module: unquote(handler),
-          aggregate_module: unquote(aggregate),
-          identity: unquote(identity),
-          timeout: unquote(timeout),
-          middleware: @registered_middleware,
-        })
+        do_dispatch(command, unquote(timeout))
       end
 
       @doc """
@@ -76,9 +125,14 @@ defmodule Commanded.Commands.Router do
       @spec dispatch(command :: struct, timeout :: integer | :infinity) :: :ok | {:error, reason :: term}
       def dispatch(command, timeout)
       def dispatch(%unquote(command_module){} = command, timeout) do
+        do_dispatch(command, timeout)
+      end
+
+      defp do_dispatch(%unquote(command_module){} = command, timeout) do
         Commanded.Commands.Dispatcher.dispatch(%Commanded.Commands.Dispatcher.Payload{
           command: command,
           handler_module: unquote(handler),
+          handler_function: unquote(function),
           aggregate_module: unquote(aggregate),
           identity: unquote(identity),
           timeout: timeout,

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Commanded.Mixfile do
   def project do
     [
       app: :commanded,
-      version: "0.8.0",
+      version: "0.8.1",
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env),
       description: description,

--- a/test/aggregates/event_persistence_test.exs
+++ b/test/aggregates/event_persistence_test.exs
@@ -51,7 +51,7 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     {:ok, aggregate} = Registry.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    :ok = Aggregate.execute(aggregate, %AppendItems{count: 10}, AppendItemsHandler)
+    :ok = Aggregate.execute(aggregate, %AppendItems{count: 10}, AppendItemsHandler, :handle)
 
     {:ok, recorded_events} = EventStore.read_stream_forward(aggregate_uuid, 0)
 
@@ -63,7 +63,7 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     {:ok, aggregate} = Registry.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    :ok = Aggregate.execute(aggregate, %AppendItems{count: 10}, AppendItemsHandler)
+    :ok = Aggregate.execute(aggregate, %AppendItems{count: 10}, AppendItemsHandler, :handle)
 
     Commanded.Helpers.Process.shutdown(aggregate)
 
@@ -82,9 +82,9 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     {:ok, aggregate} = Registry.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    :ok = Aggregate.execute(aggregate, %AppendItems{count: 100}, AppendItemsHandler)
-    :ok = Aggregate.execute(aggregate, %AppendItems{count: 100}, AppendItemsHandler)
-    :ok = Aggregate.execute(aggregate, %AppendItems{count: 1}, AppendItemsHandler)
+    :ok = Aggregate.execute(aggregate, %AppendItems{count: 100}, AppendItemsHandler, :handle)
+    :ok = Aggregate.execute(aggregate, %AppendItems{count: 100}, AppendItemsHandler, :handle)
+    :ok = Aggregate.execute(aggregate, %AppendItems{count: 1}, AppendItemsHandler, :handle)
 
     Commanded.Helpers.Process.shutdown(aggregate)
 

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -8,32 +8,86 @@ defmodule Commanded.Commands.RoutingCommandsTest do
 
   defmodule UnregisteredCommand, do: defstruct [aggregate_uuid: UUID.uuid4]
 
-  defmodule ExampleRouter do
-    use Commanded.Commands.Router
+  describe "routing to command handler" do
+    defmodule CommandHandlerRouter do
+      use Commanded.Commands.Router
 
-    dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
-    dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount, identity: :account_number
+      dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
+      dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount, identity: :account_number
+    end
+
+    test "should dispatch command to registered handler" do
+      :ok = CommandHandlerRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
+    end
+
+    test "should fail to dispatch unregistered command" do
+      {:error, :unregistered_command} = CommandHandlerRouter.dispatch(%UnregisteredCommand{})
+    end
+
+    test "should fail to dispatch command with nil identity" do
+      {:error, :invalid_aggregate_identity} = CommandHandlerRouter.dispatch(%OpenAccount{account_number: nil, initial_balance: 1_000})
+    end
   end
 
-  test "should dispatch command to registered handler" do
-    :ok = ExampleRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
-  end
+  describe "routing to aggregate" do
+    defmodule Command, do: defstruct [uuid: nil]
 
-  test "should fail to dispatch unregistered command" do
-    {:error, :unregistered_command} = ExampleRouter.dispatch(%UnregisteredCommand{})
+    defmodule AggregateRoot do
+      defstruct [uuid: nil]
+
+      def execute(%AggregateRoot{}, %Command{}), do: []
+    end
+
+    defmodule AggregateRouter do
+      use Commanded.Commands.Router
+
+      dispatch Command, to: AggregateRoot, identity: :uuid
+    end
+
+    test "should dispatch command to registered handler" do
+      :ok = AggregateRouter.dispatch(%Command{uuid: UUID.uuid4})
+    end
+
+    test "should fail to dispatch unregistered command" do
+      {:error, :unregistered_command} = AggregateRouter.dispatch(%UnregisteredCommand{})
+    end
   end
 
   test "should prevent duplicate registrations for a command" do
     # compile time safety net to prevent duplicate command registrations
-    assert_raise RuntimeError, "duplicate command registration for: Elixir.Commanded.ExampleDomain.BankAccount.Commands.OpenAccount", fn ->
+    assert_raise RuntimeError, "duplicate command registration for: Commanded.ExampleDomain.BankAccount.Commands.OpenAccount", fn ->
       Code.eval_string """
+        alias Commanded.ExampleDomain.BankAccount
         alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+
+        defmodule Handler do
+          def handle(%BankAccount{}, %OpenAccount{}), do: []
+        end
 
         defmodule DuplicateRouter do
           use Commanded.Commands.Router
 
-          dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
-          dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
+          dispatch OpenAccount, to: Handler, aggregate: BankAccount, identity: :account_number
+          dispatch OpenAccount, to: Handler, aggregate: BankAccount, identity: :account_number
+        end
+      """
+    end
+  end
+
+  test "should prevent registration for a command handler without a `handle/2` function" do
+    # compile time safety net to prevent duplicate command registrations
+    assert_raise RuntimeError, "command handler InvalidHandler does not define a function: handle/2", fn ->
+      Code.eval_string """
+        alias Commanded.ExampleDomain.BankAccount
+        alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+
+        defmodule InvalidHandler do
+        end
+
+        defmodule InvalidRouter do
+          use Commanded.Commands.Router
+
+          dispatch OpenAccount, to: InvalidHandler, aggregate: BankAccount, identity: :account_number
         end
       """
     end
@@ -61,9 +115,5 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   test "should allow multiple module registrations for different command handlers" do
     :ok = MultiCommandHandlerRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
     :ok = MultiCommandHandlerRouter.dispatch(%DepositMoney{account_number: "ACC123", amount: 100})
-  end
-
-  test "should fail to dispatch command with nil identity" do
-    {:error, :invalid_aggregate_identity} = ExampleRouter.dispatch(%OpenAccount{account_number: nil, initial_balance: 1_000})
   end
 end

--- a/test/process_managers/resume_process_manager_test.exs
+++ b/test/process_managers/resume_process_manager_test.exs
@@ -112,6 +112,9 @@ defmodule Commanded.ProcessManager.ResumeProcessManagerTest do
 
     Helpers.Process.shutdown(process_router)
 
+    # wait for subscription to receive DOWN notification and remove subscription's PID
+    :timer.sleep(1_000)
+
     {:ok, process_router} = ProcessRouter.start_link("ExampleProcessManager", ExampleProcessManager, ExampleRouter)
 
     :ok = ExampleRouter.dispatch(%ResumeProcess{process_uuid: process_uuid, status: "resume"})


### PR DESCRIPTION
Command handlers should be optional to reduce boilerplate code. The default behaviour will be to configure a router to dispatch the command directly to its aggregate.

In your router you set the `to:` as the aggregate root itself. The `aggregate:` key is not required.

```elixir
defmodule ExampleRouter do
  use Commanded.Commands.Router

  dispatch OpenAccount, to: BankAccount, identity: :account_number
  dispatch DepositMoney, to: BankAccount, identity: :account_number
end
``

By default the command will be dispatched to an aggregate root function named execute. Pattern matching will ensure that it invokes the correct function for a given command struct.

It is still be possible to configure a command handler as the `to:` target in your router when needed.