### PR TITLE
Event handler and process manager subscriptions should be created from a given stream position 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Enhancements
 
-- Middleware `after_failure` callback is executed even when a middleware halts execution. 
+- Event handler and process manager subscriptions should be created from a given stream position ([#14](https://github.com/slashdotdash/commanded/issues/14)).
+
+## v0.8.3
+
+### Enhancements
+
+- Middleware `after_failure` callback is executed even when a middleware halts execution.
 
 ## v0.8.2
 

--- a/README.md
+++ b/README.md
@@ -39,8 +39,7 @@ The package can be installed from hex as follows.
       password: "postgres",
       database: "eventstore_dev",
       hostname: "localhost",
-      pool_size: 10,
-      extensions: [{Postgrex.Extensions.Calendar, []}]
+      pool_size: 10
     ```
 
   4. Create the `eventstore` database and tables using the `mix` task.

--- a/README.md
+++ b/README.md
@@ -281,9 +281,11 @@ end
 Register the event handler with a given name. The name is used when subscribing to the event store to record the last seen event.
 
 ```elixir
-{:ok, _} = AccountBalanceHandler.start_link
-{:ok, _} = Commanded.Event.Handler.start_link("account_balance", AccountBalanceHandler)
+{:ok, _balance} = AccountBalanceHandler.start_link
+{:ok, _handler} = Commanded.Event.Handler.start_link("account_balance", AccountBalanceHandler, start_from: :origin)
 ```
+
+You should use a [supervisor](#Supervision) to start your event handlers to ensure they are restarted on error.
 
 ### Process managers
 
@@ -387,10 +389,10 @@ defmodule Bank.Supervisor do
       supervisor(Commanded.Supervisor, []),
 
       # process manager
-      worker(Commanded.ProcessManagers.ProcessRouter, ["TransferMoneyProcessManager", TransferMoneyProcessManager, BankRouter], id: :transfer_money_process_manager),
+      worker(Commanded.ProcessManagers.ProcessRouter, ["TransferMoneyProcessManager", TransferMoneyProcessManager, BankRouter, start_from: :current], id: :transfer_money_process_manager),
 
       # event handler
-      worker(Commanded.Event.Handler, ["AccountBalanceHandler", AccountBalanceHandler], id: :account_balance_handler)
+      worker(Commanded.Event.Handler, ["AccountBalanceHandler", AccountBalanceHandler, start_from: :origin], id: :account_balance_handler)
     ]
 
     supervise(children, strategy: :one_for_one)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,22 @@ MIT License
 
 [![Build Status](https://travis-ci.org/slashdotdash/commanded.svg?branch=master)](https://travis-ci.org/slashdotdash/commanded) [![Join the chat at https://gitter.im/commanded/Lobby](https://badges.gitter.im/commanded/Lobby.svg)](https://gitter.im/commanded/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
+---
+
+### Overview
+
+- [Getting started](#getting-started)
+- [Aggregate roots](#aggregate-roots)
+- [Commands](#commands)
+  - [Command handlers](#command-handlers)
+  - [Command dispatch and routing](#command-dispatch-and-routing)
+- [Middleware](#middleware)
+- [Event handlers](#event-handlers)
+- [Process managers](#process-managers)
+- [Supervision](#supervision)
+- [Serialization](#serialization)
+- [Contributing](#contributing)
+
 ## Getting started
 
 The package can be installed from hex as follows.

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,5 +6,4 @@ config :eventstore, EventStore.Storage,
   password: "postgres",
   database: "commanded_dev",
   hostname: "localhost",
-  pool_size: 10,
-  extensions: [{Postgrex.Extensions.Calendar, []}]
+  pool_size: 10

--- a/config/test.exs
+++ b/config/test.exs
@@ -11,5 +11,4 @@ config :eventstore, EventStore.Storage,
   password: "postgres",
   database: "commanded_test",
   hostname: "localhost",
-  pool_size: 1,
-  extensions: [{Postgrex.Extensions.Calendar, []}]
+  pool_size: 1

--- a/lib/commanded/process_managers/process_router.ex
+++ b/lib/commanded/process_managers/process_router.ex
@@ -13,6 +13,7 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
       process_manager_name: nil,
       process_manager_module: nil,
       command_dispatcher: nil,
+      subscribe_from: nil,
       process_managers: %{},
       supervisor: nil,
       last_seen_event_id: nil,
@@ -21,11 +22,12 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
     ]
   end
 
-  def start_link(process_manager_name, process_manager_module, command_dispatcher) do
+  def start_link(process_manager_name, process_manager_module, command_dispatcher, opts \\ []) do
     GenServer.start_link(__MODULE__, %State{
       process_manager_name: process_manager_name,
       process_manager_module: process_manager_module,
-      command_dispatcher: command_dispatcher
+      command_dispatcher: command_dispatcher,
+      subscribe_from: opts[:start_from] || :origin,
     })
   end
 
@@ -74,8 +76,8 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
   @doc """
   Subscribe the process router to all events
   """
-  def handle_cast({:subscribe_to_events}, %State{process_manager_name: process_manager_name} = state) do
-    {:ok, _} = EventStore.subscribe_to_all_streams(process_manager_name, self)
+  def handle_cast({:subscribe_to_events}, %State{process_manager_name: process_manager_name, subscribe_from: subscribe_from} = state) do
+    {:ok, _} = EventStore.subscribe_to_all_streams(process_manager_name, self, subscribe_from)
     {:noreply, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Commanded.Mixfile do
   def project do
     [
       app: :commanded,
-      version: "0.8.3",
+      version: "0.8.4",
       elixir: "~> 1.3",
       elixirc_paths: elixirc_paths(Mix.env),
       description: description,

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Commanded.Mixfile do
 
   defp deps do
     [
-      {:eventstore, "~> 0.6"},
+      {:eventstore, "~> 0.7"},
       {:ex_doc, "~> 0.14", only: :dev},
       {:markdown, github: "devinus/markdown", only: :dev},
       {:mix_test_watch, "~> 0.2", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -2,8 +2,8 @@
   "db_connection": {:hex, :db_connection, "1.1.0", "b2b88db6d7d12f99997b584d09fad98e560b817a20dab6a526830e339f54cdb3", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "eventstore": {:hex, :eventstore, "0.6.2", "c6e8badf9e35d2f7e19d8ac41a0781bbcc22ccf87a0c473b5c2b137ace76cd33", [:mix], [{:fsm, "~> 0.2", [hex: :fsm, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.12", [hex: :postgrex, optional: false]}]},
-  "ex_doc": {:hex, :ex_doc, "0.14.4", "a0a79a6896075814f4bc6802b74ccbed6549f47cc5ab34c71eaee2303170b8ef", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
+  "eventstore": {:hex, :eventstore, "0.7.0", "28f56f56d15604ac513004ea2daa42d68ebe1396d93790ee01d0c82d14b356e3", [:mix], [{:fsm, "~> 0.2", [hex: :fsm, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13", [hex: :postgrex, optional: false]}]},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "fsm": {:hex, :fsm, "0.2.0", "53bcc0fd4a470c92cbbc3bae2d7f7dd8462898eedd62c37a6be556b94fba0e05", [:mix], []},
   "hoedown": {:git, "https://github.com/hoedown/hoedown.git", "980b9c549b4348d50b683ecee6abee470b98acda", []},
@@ -11,5 +11,5 @@
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
-  "postgrex": {:hex, :postgrex, "0.12.1", "2f8b46cb3a44dcd42f42938abedbfffe7e103ba4ce810ccbeee8dcf27ca0fb06", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.0-rc.4", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
+  "postgrex": {:hex, :postgrex, "0.13.0", "e101ab47d0725955c5c8830ae8812412992e02e4bd9db09e17abb0a5d82d09c7", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [:mix], []}}

--- a/test/event/handle_event_test.exs
+++ b/test/event/handle_event_test.exs
@@ -57,7 +57,6 @@ defmodule Commanded.Event.HandleEventTest do
     assert AccountBalanceHandler.current_balance == 1_050
   end
 
-  @tag :wip
   test "should ignore events created before the event handler's subscription when starting from `current`" do
     {:ok, _} = AppendingEventHandler.start_link
 
@@ -77,7 +76,6 @@ defmodule Commanded.Event.HandleEventTest do
     assert pluck(AppendingEventHandler.received_metadata, :event_id) == [2]
 	end
 
-  @tag :wip
   test "should receive events created before the event handler's subscription when starting from `origin`" do
     {:ok, _} = AppendingEventHandler.start_link
 

--- a/test/process_managers/process_router_process_pending_events_test.exs
+++ b/test/process_managers/process_router_process_pending_events_test.exs
@@ -153,6 +153,8 @@ defmodule Commanded.ProcessManager.ProcessRouterProcessPendingEventsTest do
       %Stopped{aggregate_uuid: aggregate_uuid},
     ]
 
+    :timer.sleep 100
+
     %{items: items} = ProcessRouter.process_state(process_router, aggregate_uuid)
     assert items == [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
   end
@@ -209,7 +211,7 @@ defmodule Commanded.ProcessManager.ProcessRouterProcessPendingEventsTest do
     :ok = Router.dispatch(%Publish{aggregate_uuid: aggregate_uuid, interesting: 6, uninteresting: 0})
 
     wait_for_event Interested, fn event -> event.index == 6 end
-    :timer.sleep 1_000
+    :timer.sleep 100
 
     %{items: items} = ProcessRouter.process_state(process_router, aggregate_uuid)
     assert items == [1, 2, 3, 4, 5, 6]

--- a/test/process_managers/process_router_process_pending_events_test.exs
+++ b/test/process_managers/process_router_process_pending_events_test.exs
@@ -76,7 +76,7 @@ defmodule Commanded.ProcessManager.ProcessRouterProcessPendingEventsTest do
 
   defmodule ExampleProcessManager do
     @behaviour Commanded.ProcessManagers.ProcessManager
-    
+
     defstruct [
       status: nil,
       items: [],
@@ -193,5 +193,25 @@ defmodule Commanded.ProcessManager.ProcessRouterProcessPendingEventsTest do
       %Interested{aggregate_uuid: aggregate_uuid, index: 10},
       %Stopped{aggregate_uuid: aggregate_uuid},
     ]
+  end
+
+  test "should ignore past events when starting subscription from current" do
+    aggregate_uuid = UUID.uuid4
+
+    :ok = Router.dispatch(%Start{aggregate_uuid: aggregate_uuid})
+    :ok = Router.dispatch(%Publish{aggregate_uuid: aggregate_uuid, interesting: 4, uninteresting: 0})
+
+    wait_for_event Interested, fn event -> event.index == 4 end
+
+    {:ok, process_router} = ProcessRouter.start_link("example_process_manager", ExampleProcessManager, Router, start_from: :current)
+
+    :ok = Router.dispatch(%Start{aggregate_uuid: aggregate_uuid})
+    :ok = Router.dispatch(%Publish{aggregate_uuid: aggregate_uuid, interesting: 6, uninteresting: 0})
+
+    wait_for_event Interested, fn event -> event.index == 6 end
+    :timer.sleep 1_000
+
+    %{items: items} = ProcessRouter.process_state(process_router, aggregate_uuid)
+    assert items == [1, 2, 3, 4, 5, 6]
   end
 end

--- a/test/process_managers/resume_process_manager_test.exs
+++ b/test/process_managers/resume_process_manager_test.exs
@@ -105,6 +105,8 @@ defmodule Commanded.ProcessManager.ResumeProcessManagerTest do
       assert event.status == "start"
     end
 
+    :timer.sleep 100
+
     # wait for process instance to receive event
     Wait.until(fn ->
       %{status_history: ["start"]} = ProcessRouter.process_state(process_router, process_uuid)


### PR DESCRIPTION
Fixes #14.

When registering a new event handler or process manager the subscription it initially creates should be created from the position provided to the `start_link` function. This allows the user to determine which events it receives. By default this should be the origin position so that all events are received.

You can choose to start a subscription from the current event store position. Use this when you don't want newly created event handlers or process managers to go through all previous events (e.g. event handler to send transactional emails added to a deployed system).