### PR TITLE
Stop process manager instance after reaching its final state 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 
 elixir:
-  - 1.3.2
+  - 1.3.4
 
 otp_release:
   - 18.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## v0.8.3
+## v0.8.4
 
 ### Enhancements
 
 - Event handler and process manager subscriptions should be created from a given stream position ([#14](https://github.com/slashdotdash/commanded/issues/14)).
+- Stop process manager instance after reaching its final state ([#24](https://github.com/slashdotdash/commanded/issues/24)).
 
 ## v0.8.3
 

--- a/README.md
+++ b/README.md
@@ -326,11 +326,12 @@ The `interested?/1` function is used to indicate which events the process manage
 
 - Return `{:start, process_uuid}` to create a new instance of the process manager.
 - Return `{:continue, process_uuid}` to continue execution of an existing process manager.
+- Return `{:stop, process_uuid}` to stop an existing process manager and shutdown its process.
 - Return `false` to ignore the event.
 
 #### `handle/2`
 
-A `handle/2` function must exist for each interested event previously specified. It receives the process manager's state and the event to be handled. It must return the commands to be dispatched. This may be none, a single command, or many commands.
+A `handle/2` function must exist for each `:start` and `:continue` tagged event previously specified. It receives the process manager's state and the event to be handled. It must return the commands to be dispatched. This may be none, a single command, or many commands.
 
 #### `apply/2`
 

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -39,6 +39,13 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   end
 
   @doc """
+  Stop the given process manager, typically when it has reached its final state
+  """
+  def stop(process_manager) do
+    GenServer.stop(process_manager)
+  end
+
+  @doc """
   Fetch the process state of this instance
   """
   def process_state(process_manager) do

--- a/lib/commanded/process_managers/process_manager_instance.ex
+++ b/lib/commanded/process_managers/process_manager_instance.ex
@@ -2,6 +2,7 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   @moduledoc """
   Defines an instance of a process manager.
   """
+
   use GenServer
   require Logger
 
@@ -39,10 +40,12 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   end
 
   @doc """
-  Stop the given process manager, typically when it has reached its final state
+  Stop the given process manager and delete its persisted state.
+
+  Typically called when it has reached its final state.
   """
   def stop(process_manager) do
-    GenServer.stop(process_manager)
+    GenServer.call(process_manager, {:stop})
   end
 
   @doc """
@@ -50,6 +53,13 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
   """
   def process_state(process_manager) do
     GenServer.call(process_manager, {:process_state})
+  end
+
+  def handle_call({:stop}, _from, %ProcessManagerInstance{} = state) do
+    delete_state(state)
+
+    # stop the process with a normal reason
+    {:stop, :normal, :ok, state}
   end
 
   def handle_call({:process_state}, _from, %ProcessManagerInstance{process_state: process_state} = state) do
@@ -134,6 +144,10 @@ defmodule Commanded.ProcessManagers.ProcessManagerInstance do
       source_type: Atom.to_string(process_manager_module),
       data: process_state
     })
+  end
+
+  defp delete_state(%ProcessManagerInstance{} = state) do
+    :ok = EventStore.delete_snapshot(process_state_uuid(state))
   end
 
   defp ack_event(%EventStore.RecordedEvent{event_id: event_id}, process_router) do

--- a/lib/commanded/process_managers/process_router.ex
+++ b/lib/commanded/process_managers/process_router.ex
@@ -132,6 +132,7 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
     {process_uuid, process_manager} = case process_manager_module.interested?(data) do
       {:start, process_uuid} -> {process_uuid, start_process_manager(process_uuid, state)}
       {:continue, process_uuid} -> {process_uuid, continue_process_manager(process_uuid, state)}
+      {:stop, process_uuid} -> {:stopped, stop_process_manager(process_uuid, state)}
       false -> {nil, nil}
     end
 
@@ -139,10 +140,13 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
       nil ->
         Logger.debug(fn -> "process router \"#{process_manager_name}\" is not interested in event id: #{event_id}" end)
 
-        # no process instance, continue processing any pending events and confirm receipt of this event
-        GenServer.cast(self, {:process_pending_events})
+        ack_and_continue(state, event_id)
 
-        confirm_receipt(state, event_id)
+      :stopped ->
+        Logger.debug(fn -> "process manager instance \"#{process_manager_name}\" has been stopped by event id: #{event_id}" end)
+
+        ack_and_continue(state, event_id)
+
       _ ->
         Logger.debug(fn -> "process router \"#{process_manager_name}\" is interested in event id: #{event_id}" end)
 
@@ -151,6 +155,13 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
 
         %State{state | process_managers: Map.put(process_managers, process_uuid, process_manager)}
     end
+  end
+
+  # continue processing any pending events and confirm receipt of the given event id
+  defp ack_and_continue(%State{} = state, event_id) do
+    GenServer.cast(self, {:process_pending_events})
+
+    confirm_receipt(state, event_id)
   end
 
   # confirm receipt of given event
@@ -172,6 +183,15 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
     case Map.get(process_managers, process_uuid) do
       nil -> start_process_manager(process_uuid, state)
       process_manager -> process_manager
+    end
+  end
+
+  defp stop_process_manager(process_uuid, %State{process_managers: process_managers} = state) do
+    case Map.get(process_managers, process_uuid) do
+      nil -> nil
+      process_manager ->
+        ProcessManagerInstance.stop(process_manager)
+        nil
     end
   end
 

--- a/lib/commanded/process_managers/process_router.ex
+++ b/lib/commanded/process_managers/process_router.ex
@@ -49,16 +49,16 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
   end
 
   @doc """
-  Fetch the state of an individual process manager instance identified by the given `process_uuid`
+  Fetch the pid of an individual process manager instance identified by the given `process_uuid`
   """
-  def process_state(process_router, process_uuid) do
-    GenServer.call(process_router, {:process_state, process_uuid})
+  def process_instance(process_router, process_uuid) do
+    GenServer.call(process_router, {:process_instance, process_uuid})
   end
 
-  def handle_call({:process_state, process_uuid}, _from, %State{process_managers: process_managers} = state) do
+  def handle_call({:process_instance, process_uuid}, _from, %State{process_managers: process_managers} = state) do
     reply = case Map.get(process_managers, process_uuid) do
       nil -> {:error, :process_manager_not_found}
-      process_manager -> ProcessManagerInstance.process_state(process_manager)
+      process_manager -> process_manager
     end
 
     {:reply, reply, state}
@@ -186,11 +186,11 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
     end
   end
 
-  defp stop_process_manager(process_uuid, %State{process_managers: process_managers} = state) do
+  defp stop_process_manager(process_uuid, %State{process_managers: process_managers}) do
     case Map.get(process_managers, process_uuid) do
       nil -> nil
       process_manager ->
-        ProcessManagerInstance.stop(process_manager)
+        :ok = ProcessManagerInstance.stop(process_manager)
         nil
     end
   end

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "db_connection": {:hex, :db_connection, "1.1.0", "b2b88db6d7d12f99997b584d09fad98e560b817a20dab6a526830e339f54cdb3", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "eventstore": {:hex, :eventstore, "0.7.0", "28f56f56d15604ac513004ea2daa42d68ebe1396d93790ee01d0c82d14b356e3", [:mix], [{:fsm, "~> 0.2", [hex: :fsm, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13", [hex: :postgrex, optional: false]}]},
+  "eventstore": {:hex, :eventstore, "0.7.1", "768b17538cba6647b285039712834cf041a2c6f8b6ecd3a0c2a8eede43d59ca3", [:mix], [{:fsm, "~> 0.2", [hex: :fsm, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13", [hex: :postgrex, optional: false]}]},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "fsm": {:hex, :fsm, "0.2.0", "53bcc0fd4a470c92cbbc3bae2d7f7dd8462898eedd62c37a6be556b94fba0e05", [:mix], []},

--- a/test/process_managers/resume_process_manager_test.exs
+++ b/test/process_managers/resume_process_manager_test.exs
@@ -3,7 +3,7 @@ defmodule Commanded.ProcessManager.ResumeProcessManagerTest do
 
   alias Commanded.Helpers
   alias Commanded.Helpers.Wait
-  alias Commanded.ProcessManagers.ProcessRouter
+  alias Commanded.ProcessManagers.{ProcessRouter,ProcessManagerInstance}
 
   import Commanded.Assertions.EventAssertions
 
@@ -109,7 +109,8 @@ defmodule Commanded.ProcessManager.ResumeProcessManagerTest do
 
     # wait for process instance to receive event
     Wait.until(fn ->
-      %{status_history: ["start"]} = ProcessRouter.process_state(process_router, process_uuid)
+      process_instance = ProcessRouter.process_instance(process_router, process_uuid)
+      %{status_history: ["start"]} = ProcessManagerInstance.process_state(process_instance)
     end)
 
     Helpers.Process.shutdown(process_router)
@@ -123,9 +124,11 @@ defmodule Commanded.ProcessManager.ResumeProcessManagerTest do
 
     wait_for_event(ProcessResumed, fn event -> event.process_uuid == process_uuid end)
 
-    case ProcessRouter.process_state(process_router, process_uuid) do
+    case ProcessRouter.process_instance(process_router, process_uuid) do
       {:error, :process_manager_not_found} -> flunk("process state not available")
-      state -> assert state.status_history == ["start", "resume"]
+      process_instance ->
+        state = ProcessManagerInstance.process_state(process_instance)
+        assert state.status_history == ["start", "resume"]
     end
   end
 end


### PR DESCRIPTION
Extend process manager `interested?/2` behaviour to support returning a `:stop` response. 

This will stop execution of an existing process instance, shutdown the process, and delete its persisted state from the event store.

```elixir
defmodule TransferMoneyProcessManager do
  # ...

  def interested?(%MoneyTransferRequested{transfer_uuid: transfer_uuid}), do: {:start, transfer_uuid}
  def interested?(%MoneyWithdrawn{transfer_uuid: transfer_uuid}), do: {:continue, transfer_uuid}
  def interested?(%MoneyDeposited{transfer_uuid: transfer_uuid}), do: {:continue, transfer_uuid}
  def interested?(%MoneyTransferCompleted{transfer_uuid: transfer_uuid}), do: {:stop, transfer_uuid}
  def interested?(_event), do: false

 # ...
end
```