### PR TITLE
WIP: Wires in support for Causation IDs

### DIFF
--- a/lib/commanded/event/mapper.ex
+++ b/lib/commanded/event/mapper.ex
@@ -3,13 +3,14 @@ defmodule Commanded.Event.Mapper do
   Map raw events to event data structs ready to be persisted to the event store.
   """
 
-  def map_to_event_data(events, correlation_id) when is_list(events) do
-    Enum.map(events, &map_to_event_data(&1, correlation_id))
+  def map_to_event_data(events, correlation_id, causation_id) when is_list(events) do
+    Enum.map(events, &map_to_event_data(&1, correlation_id, causation_id))
   end
 
-  def map_to_event_data(event, correlation_id) do
+  def map_to_event_data(event, correlation_id, causation_id) do
     %EventStore.EventData{
       correlation_id: correlation_id,
+      causation_id: causation_id,
       event_type: Atom.to_string(event.__struct__),
       data: event,
       metadata: %{}

--- a/mix.exs
+++ b/mix.exs
@@ -33,7 +33,7 @@ defmodule Commanded.Mixfile do
 
   defp deps do
     [
-      {:eventstore, "~> 0.8"},
+      {:eventstore, github: "harukizaemon/eventstore", branch: "causation-ids"},
       {:ex_doc, "~> 0.14", only: :dev},
       {:markdown, github: "devinus/markdown", only: :dev},
       {:mix_test_watch, "~> 0.2", only: :dev},

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{"connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
-  "db_connection": {:hex, :db_connection, "1.1.0", "b2b88db6d7d12f99997b584d09fad98e560b817a20dab6a526830e339f54cdb3", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
+  "db_connection": {:hex, :db_connection, "1.1.2", "2865c2a4bae0714e2213a0ce60a1b12d76a6efba0c51fbda59c9ab8d1accc7a8", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: true]}, {:sbroker, "~> 1.0", [hex: :sbroker, optional: true]}]},
   "decimal": {:hex, :decimal, "1.3.1", "157b3cedb2bfcb5359372a7766dd7a41091ad34578296e951f58a946fcab49c6", [:mix], []},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "eventstore": {:hex, :eventstore, "0.8.0", "677c8897d97b263b4358370bea3be4220df814f483fcd281a45e4db19fb3dee0", [:mix], [{:fsm, "~> 0.3", [hex: :fsm, optional: false]}, {:poolboy, "~> 1.5", [hex: :poolboy, optional: false]}, {:postgrex, "~> 0.13", [hex: :postgrex, optional: false]}]},
+  "eventstore": {:git, "https://github.com/harukizaemon/eventstore.git", "b1cb7851aedf75167d3d5490cb8649db9ef095b9", [branch: "causation-ids"]},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], []},
   "fsm": {:hex, :fsm, "0.3.0", "d00e0a3c68f8cf8feb24ce3a732164638ec652c48ce416b66d4e375b6ee415eb", [:mix], []},
@@ -11,5 +11,5 @@
   "mix_test_watch": {:hex, :mix_test_watch, "0.2.6", "9fcc2b1b89d1594c4a8300959c19d50da2f0ff13642c8f681692a6e507f92cab", [:mix], [{:fs, "~> 0.9.1", [hex: :fs, optional: false]}]},
   "poison": {:hex, :poison, "3.0.0", "625ebd64d33ae2e65201c2c14d6c85c27cc8b68f2d0dd37828fde9c6920dd131", [:mix], []},
   "poolboy": {:hex, :poolboy, "1.5.1", "6b46163901cfd0a1b43d692657ed9d7e599853b3b21b95ae5ae0a777cf9b6ca8", [:rebar], []},
-  "postgrex": {:hex, :postgrex, "0.13.0", "e101ab47d0725955c5c8830ae8812412992e02e4bd9db09e17abb0a5d82d09c7", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
+  "postgrex": {:hex, :postgrex, "0.13.2", "2b88168fc6a5456a27bfb54ccf0ba4025d274841a7a3af5e5deb1b755d95154e", [:mix], [{:connection, "~> 1.0", [hex: :connection, optional: false]}, {:db_connection, "~> 1.1", [hex: :db_connection, optional: false]}, {:decimal, "~> 1.0", [hex: :decimal, optional: false]}]},
   "uuid": {:hex, :uuid, "1.1.6", "4927232f244e69c6e255643014c2d639dad5b8313dc2a6976ee1c3724e6ca60d", [:mix], []}}

--- a/test/helpers/event_factory.ex
+++ b/test/helpers/event_factory.ex
@@ -1,7 +1,7 @@
 defmodule Commanded.Helpers.EventFactory do
   def map_to_recorded_events(events) do
     events
-    |> Commanded.Event.Mapper.map_to_event_data(UUID.uuid4)
+    |> Commanded.Event.Mapper.map_to_event_data(UUID.uuid4, UUID.uuid4)
     |> Enum.with_index(1)
     |> Enum.map(fn {event, index} ->
       %EventStore.RecordedEvent{
@@ -9,6 +9,7 @@ defmodule Commanded.Helpers.EventFactory do
         stream_id: 1,
         stream_version: index,
         correlation_id: event.correlation_id,
+        causation_id: event.causation_id,
         event_type: event.event_type,
         data: event.data,
         metadata: event.metadata,


### PR DESCRIPTION
TODO: Not sure how to do this given I don't have a good feeling for the framework principles.

Correlation ID: Typically, a ProcessManager would copy the Correlation ID from the event.  This allows the Correlation ID to propagate and makes it easy to isolate a chain of events.  In the case of a user-driven command such as via a UI the Correlation ID would be synthesized as now.

Causation ID: Typically, a ProcessManager would use the Event ID as the Causation ID.  This allows the Causation ID to propagate and makes it esy to isolate specific cause-effect relationships.  In the case of a user-driven comand uch as via a UI the Causation ID would either be left null, or in some frameworks assigned the Command ID if there is one.  However, as it stands, Event IDs are integer, rather than UUIDs making this difficult.