### PR TITLE
Shutdown idle aggregate processes.

### DIFF
--- a/lib/commanded/aggregates/aggregate_lifespan.ex
+++ b/lib/commanded/aggregates/aggregate_lifespan.ex
@@ -1,0 +1,11 @@
+defmodule Commanded.Aggregates.AggregateLifespan do
+  @type command :: struct()
+  @type timeout_or_action :: timeout() | :hibernate
+
+  @doc """
+  After specified timeout aggregate process will be stoped.
+
+  Timeout begins at start of processing a command.
+  """
+  @callback after_command(command) :: timeout_or_action
+end

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -36,6 +36,7 @@ defmodule Commanded.Commands.Router do
       @registered_commands []
       @registered_middleware []
       @default_dispatch_timeout 5_000
+      @default_lifespan Commanded.Aggregates.Aggregate.DefaultLifespan
     end
   end
 
@@ -71,9 +72,9 @@ defmodule Commanded.Commands.Router do
     end
   end
 
-  @register_params [:to, :function, :aggregate, :identity, :timeout]
+  @register_params [:to, :function, :aggregate, :identity, :timeout, :lifespan]
 
-  defmacro register(command_module, to: handler, function: function, aggregate: aggregate, identity: identity, timeout: timeout) do
+  defmacro register(command_module, to: handler, function: function, aggregate: aggregate, identity: identity, timeout: timeout, lifespan: lifespan) do
     quote do
       if Enum.member?(@registered_commands, unquote(command_module)) do
         raise "duplicate command registration for: #{inspect unquote(command_module)}"
@@ -119,6 +120,7 @@ defmodule Commanded.Commands.Router do
           aggregate_module: unquote(aggregate),
           identity: unquote(identity),
           timeout: timeout,
+          lifespan: unquote(lifespan) || @default_lifespan,
           middleware: @registered_middleware,
         })
       end

--- a/test/aggregates/aggregate_lifespan_test.exs
+++ b/test/aggregates/aggregate_lifespan_test.exs
@@ -1,0 +1,66 @@
+defmodule Commanded.Aggregates.AggregateLifespanTest do
+  use Commanded.StorageCase
+  use Commanded.EventStore
+
+  alias Commanded.ExampleDomain.BankAccount
+
+  alias Commanded.ExampleDomain.BankAccount.Commands.{
+    OpenAccount,
+    DepositMoney,
+    WithdrawMoney,
+  }
+  alias Commanded.ExampleDomain.{
+    OpenAccountHandler,
+    DepositMoneyHandler,
+    WithdrawMoneyHandler,
+  }
+
+  defmodule BankAccountLifespan do
+    @behaviour Commanded.Aggregates.AggregateLifespan
+
+    def after_command(%OpenAccount{}), do: 5
+    def after_command(%DepositMoney{}), do: 20
+  end
+
+  defmodule BankRouter do
+    use Commanded.Commands.Router
+
+    dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, lifespan: BankAccountLifespan, identity: :account_number
+    dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount, lifespan: BankAccountLifespan, identity: :account_number
+    dispatch WithdrawMoney, to: WithdrawMoneyHandler, aggregate: BankAccount, identity: :account_number
+  end
+
+  describe "aggregate started" do
+    setup do
+      aggregate_uuid = UUID.uuid4
+
+      {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(BankAccount, aggregate_uuid)
+
+      [{pid, _}] = Registry.lookup(:aggregate_registry, aggregate_uuid)
+      ref = Process.monitor(pid)
+
+      %{aggregate_uuid: aggregate_uuid, ref: ref}
+    end
+
+    test "should shutdown after timeout", %{aggregate_uuid: aggregate_uuid, ref: ref} do
+      :ok = BankRouter.dispatch(%OpenAccount{account_number: aggregate_uuid, initial_balance: 10})
+
+      assert_receive {:DOWN, ^ref, :process, _, :normal}, 10
+    end
+
+    test "should not shutdown if next command executed", %{aggregate_uuid: aggregate_uuid, ref: ref} do
+      :ok = BankRouter.dispatch(%OpenAccount{account_number: aggregate_uuid, initial_balance: 10})
+      :ok = BankRouter.dispatch(%DepositMoney{account_number: aggregate_uuid, amount: 10})
+
+      refute_receive {:DOWN, ^ref, :process, _, :normal}, 10
+      assert_receive {:DOWN, ^ref, :process, _, :normal}, 30
+    end
+
+    test "should use default lifespan when it's not specified'", %{aggregate_uuid: aggregate_uuid, ref: ref} do
+      :ok = BankRouter.dispatch(%OpenAccount{account_number: aggregate_uuid, initial_balance: 10})
+      :ok = BankRouter.dispatch(%WithdrawMoney{account_number: aggregate_uuid, amount: 10})
+
+      refute_receive {:DOWN, ^ref, :process, _, :normal}, 30
+    end
+  end
+end

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -93,6 +93,25 @@ defmodule Commanded.Commands.RoutingCommandsTest do
     end
   end
 
+  test "should show a help note when bad argument given to a `dispatch/2` function" do
+    assert_raise RuntimeError, """
+    unexpected dispatch parameter "id"
+    available params are: to, function, aggregate, identity, timeout
+    """,
+    fn ->
+      Code.eval_string """
+        alias Commanded.ExampleDomain.BankAccount
+        alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+
+        defmodule InvalidRouter do
+          use Commanded.Commands.Router
+
+          dispatch OpenAccount, to: InvalidHandler, aggregate: BankAccount, id: :account_number
+        end
+      """
+    end
+  end
+
   defmodule MultiCommandRouter do
     use Commanded.Commands.Router
 

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -96,7 +96,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   test "should show a help note when bad argument given to a `dispatch/2` function" do
     assert_raise RuntimeError, """
     unexpected dispatch parameter "id"
-    available params are: to, function, aggregate, identity, timeout
+    available params are: to, function, aggregate, identity, timeout, lifespan
     """,
     fn ->
       Code.eval_string """


### PR DESCRIPTION
I propose implementing the following behavior to manage aggregate lifetime. The main intention was that aggregate life controller should be separated entity from domain logic.

```elixir
defmodule ShopLifespan do
  @behaviour Commanded.Aggregates.AggregateLifespan

  # It specifies how long aggregate should live after processing command
  # @callback after_command(command) :: integer() | :infinity | :hibernate
  def after_command(%StartShopWork{}), do: 3600 * 1000 * 8
  def after_command(%StopShopWork{}), do: :hibernate
  def after_command(%CloseShop{}), do: 0
end
```

It should be specified in router:

```elixir
defmodule CommandRouter do
  use Commanded.Commands.Router

  dispatch [
     StartShopWork,
     StopShopWork,
     CloseShop,
  ], to: MyAggregate, lifespan: MyAggregateLifespan, identity: :aggregate_id
end
```