### PR TITLE
Allow compiling in other registry providers

### DIFF
--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -13,6 +13,7 @@ defmodule Commanded.Aggregates.Aggregate do
   alias Commanded.Aggregates.Aggregate
   alias Commanded.Event.Mapper
 
+  @registry_provider Application.get_env(:commanded, :registry_provider, Registry)
   @aggregate_registry_name :aggregate_registry
   @read_event_batch_size 100
 
@@ -39,7 +40,7 @@ defmodule Commanded.Aggregates.Aggregate do
   end
 
   defp via_tuple(aggregate_uuid) do
-    {:via, Registry, {@aggregate_registry_name, aggregate_uuid}}
+    {:via, @registry_provider, {@aggregate_registry_name, aggregate_uuid}}
   end
 
   def init(%Aggregate{} = state) do

--- a/lib/commanded/supervisor.ex
+++ b/lib/commanded/supervisor.ex
@@ -2,17 +2,29 @@ defmodule Commanded.Supervisor do
   use Supervisor
   use Commanded.EventStore
 
+  @registry_provider Application.get_env(:commanded, :registry_provider, Registry)
+
   def start_link do
     Supervisor.start_link(__MODULE__, nil)
   end
 
   def init(_) do
-    children = [
-      supervisor(Registry, [:unique, :aggregate_registry]),
+    children = registry_supervision_tree(@registry_provider) ++ [
       supervisor(Task.Supervisor, [[name: Commanded.Commands.TaskDispatcher]]),
       supervisor(Commanded.Aggregates.Supervisor, []),
     ]
 
     supervise(children, strategy: :one_for_one)
+  end
+
+  defp registry_supervision_tree(Registry) do
+    [supervisor(Registry, [:unique, :aggregate_registry])]
+  end
+
+  defp registry_supervision_tree(registry_provider) do
+    import Logger
+
+    Logger.warn("#{registry_provider} is not started or supervised by :commanded; be sure to add it to your supervision tree")
+    []
   end
 end

--- a/test/aggregates/aggregate_lifespan_test.exs
+++ b/test/aggregates/aggregate_lifespan_test.exs
@@ -15,6 +15,8 @@ defmodule Commanded.Aggregates.AggregateLifespanTest do
     WithdrawMoneyHandler,
   }
 
+  @registry_provider Application.get_env(:commanded, :registry_provider, Registry)
+
   defmodule BankAccountLifespan do
     @behaviour Commanded.Aggregates.AggregateLifespan
 
@@ -36,7 +38,7 @@ defmodule Commanded.Aggregates.AggregateLifespanTest do
 
       {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(BankAccount, aggregate_uuid)
 
-      [{pid, _}] = Registry.lookup(:aggregate_registry, aggregate_uuid)
+      pid = apply(@registry_provider, :whereis_name, [{:aggregate_registry, aggregate_uuid}])
       ref = Process.monitor(pid)
 
       %{aggregate_uuid: aggregate_uuid, ref: ref}

--- a/test/aggregates/execute_command_for_aggregate_test.exs
+++ b/test/aggregates/execute_command_for_aggregate_test.exs
@@ -10,6 +10,8 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
   alias Commanded.ExampleDomain.BankAccount.Events.BankAccountOpened
   alias Commanded.Helpers
 
+  @registry_provider Application.get_env(:commanded, :registry_provider, Registry)
+
   test "execute command against an aggregate" do
     account_number = UUID.uuid4
 
@@ -87,6 +89,6 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
 
     # process should exit
     assert_receive({:EXIT, _from, _reason})
-    assert Registry.lookup(:aggregate_registry, aggregate_uuid) == []
+    assert apply(@registry_provider, :whereis_name, [{:aggregate_registry, aggregate_uuid}]) == :undefined
   end
 end

--- a/test/helpers/process.ex
+++ b/test/helpers/process.ex
@@ -1,6 +1,8 @@
 defmodule Commanded.Helpers.Process do
   import ExUnit.Assertions
 
+  @registry_provider Application.get_env(:commanded, :registry_provider, Registry)
+
   @doc """
   Stop the given process with a non-normal exit reason
   """
@@ -13,7 +15,7 @@ defmodule Commanded.Helpers.Process do
   end
   
   def shutdown(aggregate_uuid) do
-    [{pid, _}] = Registry.lookup(:aggregate_registry, aggregate_uuid)
+    pid = apply(@registry_provider, :whereis_name, [{:aggregate_registry, aggregate_uuid}])
     shutdown(pid)
   end
 end


### PR DESCRIPTION
Gday @slashdotdash,

I'd like to use commanded across multiple nodes, the first step of which would be to be able to run it with a global process registry. This PR allows you to compile commanded using a registry provider other than `Registry` by specifying the module in config as `:registry_provider`. It will should work with any registry that supports `:via` tuples (thus the changes to the tests - `lookup` isn't one of the callbacks required to support them), while still compiling with `Registry` by default.

I was toying with the idea of writing a `Commanded.Registry.Provider` behaviour, with a default implementation using `Registry` as `Commanded.Registry` but this was the simpler option and I wanted to get feedback on the idea first.

I have a branch [here](https://github.com/brentonannan/commanded/tree/test/compile_with_syn_as_registry_provider) which is green for all tests when using [syn](https://github.com/ostinelli/syn).