### PR TITLE
Command dispatch optionally returns aggregate version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.13.0
+
+### Enhancements
+
+- Command dispatch optionally returns aggregate version, using `include_aggregate_version: true` during dispatch.
+
 ## v0.12.0
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The package can be installed from hex as follows.
 
     ```elixir
     def deps do
-      [{:commanded, "~> 0.12"}]
+      [{:commanded, "~> 0.13"}]
     end
     ```
 
@@ -340,7 +340,7 @@ end
 
 ```elixir
 # dispatch the open account command with a timeout of 2 seconds
-:ok = BankRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000}, 2_000)
+:ok = BankRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000}, timeout: 2_000)
 ```
 
 #### Multi-command registration
@@ -354,6 +354,16 @@ defmodule BankRouter do
   dispatch [OpenAccount,CloseAccount], to: BankAccountHandler, aggregate: BankAccount, identity: :account_number
 end
 ```
+
+#### Dispatch returning aggregate version
+
+You can optionally choose to include the aggregate's version as part of the dispatch result by setting the  `include_aggregate_version` option to true:
+
+```elixir
+{:ok, aggregate_version} = BankRouter.dispatch(command, include_aggregate_version: true)
+```
+
+This is useful when you need to wait for an event handler, such as a read model projection, to be up-to-date before continuing execution or querying its data.
 
 #### Aggregate lifespan
 

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -11,6 +11,7 @@ defmodule Commanded.Commands.Dispatcher do
       handler_module: nil,
       handler_function: nil,
       aggregate_module: nil,
+      include_aggregate_version: nil,
       identity: nil,
       timeout: nil,
       lifespan: nil,
@@ -54,7 +55,7 @@ defmodule Commanded.Commands.Dispatcher do
   end
 
   defp execute(
-    %Payload{handler_module: handler_module, handler_function: handler_function, timeout: timeout, lifespan: lifespan} = payload,
+    %Payload{handler_module: handler_module, handler_function: handler_function, include_aggregate_version: include_aggregate_version, timeout: timeout, lifespan: lifespan} = payload,
     %Pipeline{command: command} = pipeline,
     aggregate_uuid)
   do
@@ -71,9 +72,13 @@ defmodule Commanded.Commands.Dispatcher do
     end
 
     case result do
-      :ok = reply ->
+      {:ok, aggregate_version} ->
         after_dispatch(pipeline, payload)
-        reply
+
+        case include_aggregate_version do
+          true -> {:ok, aggregate_version}
+          false -> :ok
+        end
 
       {:error, error} = reply ->
         after_failure(pipeline, error, payload)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Commanded.Mixfile do
   def project do
     [
       app: :commanded,
-      version: "0.12.0",
+      version: "0.13.0",
       elixir: "~> 1.4",
       elixirc_paths: elixirc_paths(Mix.env),
       description: description(),

--- a/test/aggregates/event_persistence_test.exs
+++ b/test/aggregates/event_persistence_test.exs
@@ -52,7 +52,7 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    :ok = Aggregate.execute(aggregate_uuid, %AppendItems{count: 10}, AppendItemsHandler, :handle)
+    {:ok, 10} = Aggregate.execute(aggregate_uuid, %AppendItems{count: 10}, AppendItemsHandler, :handle)
 
     recorded_events = @event_store.stream_forward(aggregate_uuid, 0) |> Enum.to_list()
 
@@ -64,7 +64,7 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    :ok = Aggregate.execute(aggregate_uuid, %AppendItems{count: 10}, AppendItemsHandler, :handle)
+    {:ok, 10} = Aggregate.execute(aggregate_uuid, %AppendItems{count: 10}, AppendItemsHandler, :handle)
 
     Commanded.Helpers.Process.shutdown(aggregate_uuid)
 
@@ -82,9 +82,9 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    :ok = Aggregate.execute(aggregate_uuid, %AppendItems{count: 100}, AppendItemsHandler, :handle)
-    :ok = Aggregate.execute(aggregate_uuid, %AppendItems{count: 100}, AppendItemsHandler, :handle)
-    :ok = Aggregate.execute(aggregate_uuid, %AppendItems{count: 1}, AppendItemsHandler, :handle)
+    {:ok, 100} = Aggregate.execute(aggregate_uuid, %AppendItems{count: 100}, AppendItemsHandler, :handle)
+    {:ok, 200} = Aggregate.execute(aggregate_uuid, %AppendItems{count: 100}, AppendItemsHandler, :handle)
+    {:ok, 201} = Aggregate.execute(aggregate_uuid, %AppendItems{count: 1}, AppendItemsHandler, :handle)
 
     Commanded.Helpers.Process.shutdown(aggregate_uuid)
 

--- a/test/aggregates/execute_command_for_aggregate_test.exs
+++ b/test/aggregates/execute_command_for_aggregate_test.exs
@@ -17,7 +17,7 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
 
     {:ok, ^account_number} = Commanded.Aggregates.Supervisor.open_aggregate(BankAccount, account_number)
 
-    :ok = Aggregate.execute(account_number, %OpenAccount{account_number: account_number, initial_balance: 1_000}, BankAccount, :open_account)
+    {:ok, 1} = Aggregate.execute(account_number, %OpenAccount{account_number: account_number, initial_balance: 1_000}, BankAccount, :open_account)
 
     Helpers.Process.shutdown(account_number)
 
@@ -33,7 +33,7 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
 
     {:ok, ^account_number} = Commanded.Aggregates.Supervisor.open_aggregate(BankAccount, account_number)
 
-    :ok = Aggregate.execute(account_number, %OpenAccount{account_number: account_number, initial_balance: 1_000}, OpenAccountHandler, :handle)
+    {:ok, 1} = Aggregate.execute(account_number, %OpenAccount{account_number: account_number, initial_balance: 1_000}, OpenAccountHandler, :handle)
 
     Helpers.Process.shutdown(account_number)
 
@@ -49,7 +49,7 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
 
     {:ok, ^account_number} = Commanded.Aggregates.Supervisor.open_aggregate(BankAccount, account_number)
 
-    :ok = Aggregate.execute(account_number, %OpenAccount{account_number: account_number, initial_balance: 1_000}, OpenAccountHandler, :handle)
+    {:ok, 1} = Aggregate.execute(account_number, %OpenAccount{account_number: account_number, initial_balance: 1_000}, OpenAccountHandler, :handle)
 
     state_before = Aggregate.aggregate_state(account_number)
 

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -119,8 +119,8 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   end
 
   test "should allow multiple module registrations for multiple commands in a single dispatch" do
-    :ok = MultiCommandRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
-    :ok = MultiCommandRouter.dispatch(%CloseAccount{account_number: "ACC123"})
+    assert :ok == MultiCommandRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
+    assert :ok == MultiCommandRouter.dispatch(%CloseAccount{account_number: "ACC123"})
   end
 
   defmodule MultiCommandHandlerRouter do
@@ -132,7 +132,14 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   end
 
   test "should allow multiple module registrations for different command handlers" do
-    :ok = MultiCommandHandlerRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
-    :ok = MultiCommandHandlerRouter.dispatch(%DepositMoney{account_number: "ACC123", amount: 100})
+    assert :ok == MultiCommandHandlerRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
+    assert :ok == MultiCommandHandlerRouter.dispatch(%DepositMoney{account_number: "ACC123", amount: 100})
+  end
+
+  describe "include aggregate version" do
+    test "should return aggregate's updated stream version" do
+      assert {:ok, 1} == MultiCommandHandlerRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000}, include_aggregate_version: true)
+      assert {:ok, 2} == MultiCommandHandlerRouter.dispatch(%DepositMoney{account_number: "ACC123", amount: 100}, include_aggregate_version: true)
+    end
   end
 end


### PR DESCRIPTION
You can optionally choose to include the aggregate's updated version as part of a command dispatch result by setting `include_aggregate_version` true:

```elixir
{:ok, aggregate_version} = BankRouter.dispatch(command, include_aggregate_version: true)
```

This is useful when you need to wait for an event handler (e.g. a read model projection) to be up-to-date before continuing or querying its data.

The default is to return only `:ok`, which is the same as before this change:

```elixir
:ok = BankRouter.dispatch(command)
```