### PR TITLE
Adjust documentation to make Process Managers work

### DIFF
--- a/README.md
+++ b/README.md
@@ -609,7 +609,7 @@ defmodule Bank.Supervisor do
   def init(:ok) do
     children = [
       # process manager
-      worker(TransferMoneyProcessManager, [start_from: :current], id: :transfer_money_process_manager),
+      worker(TransferMoneyProcessManager, [[start_from: :current]], id: :transfer_money_process_manager),
 
       # event handler
       worker(AccountBalanceHandler, [start_from: :origin], id: :account_balance_handler)


### PR DESCRIPTION
If you start it with only the keyword list, the application start stops with `        ** (FunctionClauseError) no function clause matching in Keyword.merge/2` because the keyword list is not the first argument but the whole list of arguments.