### PR TITLE
Include custom metadata during command dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.14.0 (unreleased)
+
+- Dispatch command with `:eventual` or `:strong` consistency guarantee ([#82](https://github.com/slashdotdash/commanded/issues/82)).
+- Include custom metadata during command dispatch ([#61](https://github.com/slashdotdash/commanded/issues/61)).
+
 ## v0.13.0
 
 ### Enhancements

--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -4,21 +4,21 @@ defmodule Commanded.Aggregates.ExecutionContext do
 
   The available options are:
 
-    - `command` is the command to execute, typically a struct
+    - `command` - the command to execute, typically a struct
       (e.g. `%OpenBankAccount{...}`).
 
-    - `metadata` is a map of key/value pairs containing the metadata to be
+    - `metadata` - a map of key/value pairs containing the metadata to be
       associated with all events created by the command.
 
-    - `handler` is the module that handles the command. It may be either the
+    - `handler` - the module that handles the command. It may be either the
       aggregate module itself or a separate command handler module.
 
-    - `function` is the name of function, as an atom, that handles the command.
+    - `function` - the name of function, as an atom, that handles the command.
       The default value is `:execute`, used to support command dispatch directly
       to the aggregate module. For command handlers the `:handle` function is
       used.
 
-    - `lifespan` is a module implementing the `Commanded.Aggregates.AggregateLifespan`
+    - `lifespan` - a module implementing the `Commanded.Aggregates.AggregateLifespan`
       behaviour to control the aggregate instance process lifespan. The default
       value, `Commanded.Aggregates.DefaultLifespan`, keeps the process running
       indefinitely.

--- a/lib/commanded/aggregates/execution_context.ex
+++ b/lib/commanded/aggregates/execution_context.ex
@@ -1,0 +1,37 @@
+defmodule Commanded.Aggregates.ExecutionContext do
+  @moduledoc """
+  Defines the arguments used to execute a command for an aggregate.
+
+  The available options are:
+
+    - `command` is the command to execute, typically a struct
+      (e.g. `%OpenBankAccount{...}`).
+
+    - `metadata` is a map of key/value pairs containing the metadata to be
+      associated with all events created by the command.
+
+    - `handler` is the module that handles the command. It may be either the
+      aggregate module itself or a separate command handler module.
+
+    - `function` is the name of function, as an atom, that handles the command.
+      The default value is `:execute`, used to support command dispatch directly
+      to the aggregate module. For command handlers the `:handle` function is
+      used.
+
+    - `lifespan` is a module implementing the `Commanded.Aggregates.AggregateLifespan`
+      behaviour to control the aggregate instance process lifespan. The default
+      value, `Commanded.Aggregates.DefaultLifespan`, keeps the process running
+      indefinitely.
+
+  """
+
+  alias Commanded.Aggregates.DefaultLifespan
+
+  defstruct [
+    command: nil,
+    metadata: %{},
+    handler: nil,
+    function: nil,
+    lifespan: DefaultLifespan,
+  ]
+end

--- a/lib/commanded/event_store/adapters/in_memory.ex
+++ b/lib/commanded/event_store/adapters/in_memory.ex
@@ -220,11 +220,15 @@ defmodule Commanded.EventStore.Adapters.InMemory do
     {{:ok, length(stream_events)}, state}
   end
 
-  defp map_to_recorded_event(event_number, stream_uuid, stream_version, now, %EventData{correlation_id: correlation_id, event_type: event_type, data: data, metadata: metadata}) do
+  defp map_to_recorded_event(
+    event_number, stream_uuid, stream_version, now, 
+    %EventData{causation_id: causation_id, correlation_id: correlation_id, event_type: event_type, data: data, metadata: metadata})
+  do
     %RecordedEvent{
       event_number: event_number,
       stream_id: stream_uuid,
       stream_version: stream_version,
+      causation_id: causation_id,
       correlation_id: correlation_id,
       event_type: event_type,
       data: data,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Commanded.Mixfile do
   use Mix.Project
 
-  @version "0.13.0"
+  @version "0.14.0"
 
   def project do
     [

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -142,4 +142,11 @@ defmodule Commanded.Commands.RoutingCommandsTest do
       assert {:ok, 2} == MultiCommandHandlerRouter.dispatch(%DepositMoney{account_number: "ACC123", amount: 100}, include_aggregate_version: true)
     end
   end
+
+  test "should allow setting metadata" do
+    metadata = %{ip_address: "127.0.0.1"}
+
+    assert :ok == MultiCommandHandlerRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000}, metadata: metadata)
+    assert :ok == MultiCommandHandlerRouter.dispatch(%DepositMoney{account_number: "ACC123", amount: 100}, metadata: metadata)
+  end
 end


### PR DESCRIPTION
Allow metadata to be provided when dispatching a command:

```elixir
command = %OpenAccount{account_number: "ACC123", initial_balance: 1_000}
metadata = %{"user_id" => "user-12345", "ip_address" => "127.0.0.1"}

:ok = BankRouter.dispatch(command, metadata: metdata)
```

The *optional* metadata is recorded against all events created by the command. This is useful for additional auditing purposes, such as recording the user's identity, their source IP address, etc.

Fixes #61.

Thanks to @sammkj for implementing this feature.