### PR TITLE
 Validate command dispatch registration in router

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 
 elixir:
-  - 1.5.0
+  - 1.5.1
 
 otp_release:
   - 20.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # Changelog
 
-## v0.14.0 (unreleased)
+## v0.14.0
+
+### Enhancements
 
 - Dispatch command with `:eventual` or `:strong` consistency guarantee ([#82](https://github.com/slashdotdash/commanded/issues/82)).
 - Include custom metadata during command dispatch ([#61](https://github.com/slashdotdash/commanded/issues/61)).
+- Validate command dispatch registration in router ([59](https://github.com/slashdotdash/commanded/issues/59)).
 
 ## v0.13.0
 

--- a/lib/commanded/commands/router.ex
+++ b/lib/commanded/commands/router.ex
@@ -137,7 +137,7 @@ defmodule Commanded.Commands.Router do
 
   @doc false
   defmacro register(command_module, to: handler, function: function, aggregate: aggregate, identity: identity, timeout: timeout, lifespan: lifespan, consistency: consistency) do
-    quote do
+    quote location: :keep do
       if Enum.member?(@registered_commands, unquote(command_module)) do
         raise "duplicate command registration for: #{inspect unquote(command_module)}"
       end
@@ -238,7 +238,7 @@ defmodule Commanded.Commands.Router do
 
   @doc false
   def ensure_module_exists(module) do
-    unless Code.ensure_loaded?(module) do
+    unless Code.ensure_compiled?(module) do
       raise "module `#{inspect module}` does not exist, perhaps you forgot to `alias` the namespace"
     end
   end

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -112,6 +112,51 @@ defmodule Commanded.Commands.RoutingCommandsTest do
     end
   end
 
+  test "should prevent registrations for a invalid command module" do
+    assert_raise RuntimeError, "module `OpenAccount` does not exist, perhaps you forgot to `alias` the namespace", fn ->
+      Code.eval_string """
+        alias Commanded.ExampleDomain.BankAccount
+        alias Commanded.ExampleDomain.OpenAccountHandler
+
+        defmodule InvalidCommandRouter do
+          use Commanded.Commands.Router
+
+          dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
+        end
+      """
+    end
+  end
+
+  test "should prevent registrations for an invalid command handler module" do
+    assert_raise RuntimeError, "module `Handler` does not exist, perhaps you forgot to `alias` the namespace", fn ->
+      Code.eval_string """
+        alias Commanded.ExampleDomain.BankAccount
+        alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+
+        defmodule InvalidHandlerRouter do
+          use Commanded.Commands.Router
+
+          dispatch OpenAccount, to: Handler, aggregate: BankAccount, identity: :account_number
+        end
+      """
+    end
+  end
+
+  test "should prevent registrations for an invalid aggregate module" do
+    assert_raise RuntimeError, "module `BankAccount` does not exist, perhaps you forgot to `alias` the namespace", fn ->
+      Code.eval_string """
+        alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
+        alias Commanded.ExampleDomain.OpenAccountHandler
+
+        defmodule InvalidAggregateRouter do
+          use Commanded.Commands.Router
+
+          dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
+        end
+      """
+    end
+  end
+
   defmodule MultiCommandRouter do
     use Commanded.Commands.Router
 

--- a/test/commands/routing_commands_test.exs
+++ b/test/commands/routing_commands_test.exs
@@ -113,7 +113,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
   end
 
   test "should prevent registrations for a invalid command module" do
-    assert_raise RuntimeError, "module `OpenAccount` does not exist, perhaps you forgot to `alias` the namespace", fn ->
+    assert_raise RuntimeError, "module `UnknownCommand` does not exist, perhaps you forgot to `alias` the namespace", fn ->
       Code.eval_string """
         alias Commanded.ExampleDomain.BankAccount
         alias Commanded.ExampleDomain.OpenAccountHandler
@@ -121,14 +121,14 @@ defmodule Commanded.Commands.RoutingCommandsTest do
         defmodule InvalidCommandRouter do
           use Commanded.Commands.Router
 
-          dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
+          dispatch UnknownCommand, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
         end
       """
     end
   end
 
   test "should prevent registrations for an invalid command handler module" do
-    assert_raise RuntimeError, "module `Handler` does not exist, perhaps you forgot to `alias` the namespace", fn ->
+    assert_raise RuntimeError, "module `UnknownHandler` does not exist, perhaps you forgot to `alias` the namespace", fn ->
       Code.eval_string """
         alias Commanded.ExampleDomain.BankAccount
         alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
@@ -136,14 +136,14 @@ defmodule Commanded.Commands.RoutingCommandsTest do
         defmodule InvalidHandlerRouter do
           use Commanded.Commands.Router
 
-          dispatch OpenAccount, to: Handler, aggregate: BankAccount, identity: :account_number
+          dispatch OpenAccount, to: UnknownHandler, aggregate: BankAccount, identity: :account_number
         end
       """
     end
   end
 
   test "should prevent registrations for an invalid aggregate module" do
-    assert_raise RuntimeError, "module `BankAccount` does not exist, perhaps you forgot to `alias` the namespace", fn ->
+    assert_raise RuntimeError, "module `UnknownAggregate` does not exist, perhaps you forgot to `alias` the namespace", fn ->
       Code.eval_string """
         alias Commanded.ExampleDomain.BankAccount.Commands.OpenAccount
         alias Commanded.ExampleDomain.OpenAccountHandler
@@ -151,7 +151,7 @@ defmodule Commanded.Commands.RoutingCommandsTest do
         defmodule InvalidAggregateRouter do
           use Commanded.Commands.Router
 
-          dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
+          dispatch OpenAccount, to: OpenAccountHandler, aggregate: UnknownAggregate, identity: :account_number
         end
       """
     end


### PR DESCRIPTION
Ensure the command, handler, and aggregate modules exist when configured in a router module.

Fixes #59.