### PR TITLE
Additional stream prefix per aggregate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 - Dispatch command with `:eventual` or `:strong` consistency guarantee ([#82](https://github.com/slashdotdash/commanded/issues/82)).
+- Additional stream prefix per aggregate ([#77](https://github.com/slashdotdash/commanded/issues/77)).
 - Include custom metadata during command dispatch ([#61](https://github.com/slashdotdash/commanded/issues/61)).
 - Validate command dispatch registration in router ([59](https://github.com/slashdotdash/commanded/issues/59)).
 

--- a/guides/Commands.md
+++ b/guides/Commands.md
@@ -2,7 +2,7 @@
 
 ## Commands
 
-Create a module per command and define the fields with `defstruct`. A command **must contain** a field to uniquely identify the aggregate instance (e.g. `account_number`).
+You need to create a module per command and define the fields using `defstruct`:
 
 ```elixir
 defmodule OpenAccount do
@@ -10,11 +10,39 @@ defmodule OpenAccount do
 end
 ```
 
+A command **must contain** a field to uniquely identify the aggregate instance (e.g. `account_number`).
+
+## Command dispatch and routing
+
+A router module is used to route and dispatch commands to their registered command handler or aggregate module.
+
+You create a router module, using `Commanded.Commands.Router`, and register each command with its associated handler:
+
+```elixir
+defmodule BankRouter do
+  use Commanded.Commands.Router
+
+  dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
+  dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount, identity: :account_number
+end
+```
+
+This can be more succinctly configured by excluding command handlers and [dispatching directly to the aggregate root](#dispatch-directly-to-aggregate), using [multi-command registration](#multi-command-registration), and with the [`identify`](#define-aggregate-identity) helper macro:
+
+```elixir
+defmodule BankRouter do
+  use Commanded.Commands.Router
+
+  identify BankAccount, by: :account_number
+  dispatch [OpenAccount, DepositMoney], to: BankAccount
+end
+```
+
 ## Command handlers
 
-Implement the `Commanded.Commands.Handler` behaviour consisting of a single `handle/2` function.
+A command handler receives the aggregate root and the command being executed. It allows you to validate, authorize, and/or enrich the command with additional data before executing the appropriate aggregate root module function.
 
-It receives the aggregate root state and the command to be handled. It must return the raised domain events from the aggregate root. It may return an `{:error, reason}` tuple on failure.
+The command handler must implement the `Commanded.Commands.Handler` behaviour consisting of a single `handle/2` function. It receives the aggregate root state and the command to be handled. It must return the raised domain events from the aggregate root. It may return an `{:error, reason}` tuple on failure.
 
 ```elixir
 defmodule OpenAccountHandler do
@@ -27,18 +55,9 @@ defmodule OpenAccountHandler do
 end
 ```
 
-## Command dispatch and routing
+Command handlers execute in the context of the dispatch call, as such they are limited to the timeout period specified. The default time is five seconds, the same as a `GenServer` call. You can increase the timeout value for individual commands as required - see the section on [Timeouts](#timeouts) below.
 
-You must create a router to register each command with its associated handler.
-
-```elixir
-defmodule BankRouter do
-  use Commanded.Commands.Router
-
-  dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
-  dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount, identity: :account_number
-end
-```
+### Dispatch directly to aggregate
 
 It is also possible to route a command directly to an aggregate root, without requiring an intermediate command handler.
 
@@ -52,11 +71,45 @@ end
 
 The aggregate root must implement an `execute/2` function that receives the aggregate's state and the command to execute.
 
-You can then dispatch a command using the router.
+### Dispatching commands
+
+You can then dispatch a command using the router:
 
 ```elixir
 :ok = BankRouter.dispatch(%OpenAccount{account_number: "ACC123", initial_balance: 1_000})
 ```
+
+### Define aggregate identity
+
+You can define the identity field for an aggregate once using the `identify` macro. The configured identity will be used for all commands registered to the aggregate, unless overridden by a command registration.
+
+#### Example
+
+```elixir
+defmodule BankRouter do
+  use Commanded.Commands.Router
+
+  identify BankAccount, by: :account_number
+
+  dispatch OpenAccount, to: BankAccount
+end
+```
+
+An optional identity prefix can be used to distinguish between different aggregates that  would otherwise share the same identity. As an example you might have a `User` and a `UserPreferences` aggregate that you wish to share the same identity. In this scenario you should specify a `prefix` for each aggregate (e.g. "user-" and "user-preference-").
+
+```elixir
+defmodule BankRouter do
+  use Commanded.Commands.Router
+
+  identify BankAccount,
+    by: :account_number,
+    prefix: "bank-account-"
+
+  dispatch OpenAccount, to: BankAccount
+end
+```
+
+The prefix is used as the stream identity when appending, and reading, the aggregate's events.
 
 ### Timeouts
 
@@ -69,7 +122,11 @@ defmodule BankRouter do
   use Commanded.Commands.Router
 
   # configure a timeout of 1 second for the open account command handler
-  dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number, timeout: 1_000
+  dispatch OpenAccount,
+    to: OpenAccountHandler,
+    aggregate: BankAccount,
+    identity: :account_number,
+    timeout: 1_000
 end
 ```
 
@@ -81,13 +138,16 @@ You can override the timeout value during command dispatch. This example is disp
 
 ### Multi-command registration
 
-Command routers support multi command registration so you can group related command handlers into the same module.
+Command routers support multi command registration so you can group related command handlers into the same module:
 
 ```elixir
 defmodule BankRouter do
   use Commanded.Commands.Router
 
-  dispatch [OpenAccount,CloseAccount], to: BankAccountHandler, aggregate: BankAccount, identity: :account_number
+  dispatch [OpenAccount,CloseAccount],
+    to: BankAccountHandler,
+    aggregate: BankAccount,
+    identity: :account_number
 end
 ```
 
@@ -99,7 +159,7 @@ You can choose the consistency guarantee provided by a command dispatch using th
 :ok = BankRouter.dispatch(command, consistency: :strong)
 ```
 
-The available options are `:eventual` (default) and `:strong`:
+The available options are `:eventual` (default) and `:strong`.
 
 - *Strong consistency* offers up-to-date data but at the cost of high latency.
 - *Eventual consistency* offers low latency but read model queries may reply with stale data since they may not have processed the persisted events.
@@ -160,7 +220,10 @@ defmodule BankRouter do
   use Commanded.Commands.Router
 
   dispatch [OpenAccount,CloseAccount],
-    to: BankAccountHandler, aggregate: BankAccount, lifespan: BankAccountLifespan, identity: :account_number
+    to: BankAccountHandler,
+    aggregate: BankAccount,
+    lifespan: BankAccountLifespan,
+    identity: :account_number
 end
 ```
 
@@ -184,8 +247,10 @@ defmodule BankingRouter do
   middleware MyCommandValidator
   middleware AuthorizeCommand
 
-  dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount, identity: :account_number
-  dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount, identity: :account_number
+  identify BankAccount, by: :account_number
+  
+  dispatch OpenAccount, to: OpenAccountHandler, aggregate: BankAccount
+  dispatch DepositMoney, to: DepositMoneyHandler, aggregate: BankAccount
 end
 ```
 

--- a/lib/commanded/aggregates/aggregate.ex
+++ b/lib/commanded/aggregates/aggregate.ex
@@ -31,25 +31,29 @@ defmodule Commanded.Aggregates.Aggregate do
     aggregate_uuid: nil,
     aggregate_state: nil,
     aggregate_version: 0,
+    identity_prefix: nil,
   ]
 
-  def start_link(aggregate_module, aggregate_uuid) do
-    name = via_tuple(aggregate_uuid)
+  def start_link(aggregate_module, aggregate_uuid, identity_prefix \\ nil)
+  def start_link(aggregate_module, aggregate_uuid, identity_prefix) do
+    name = via_tuple(aggregate_module, aggregate_uuid)
+
     GenServer.start_link(__MODULE__, %Aggregate{
       aggregate_module: aggregate_module,
-      aggregate_uuid: aggregate_uuid
+      aggregate_uuid: aggregate_uuid,
+      identity_prefix: identity_prefix,
     },
     name: name)
   end
 
-  defp via_tuple(aggregate_uuid) do
-    {:via, @registry_provider, {@aggregate_registry_name, aggregate_uuid}}
+  defp via_tuple(aggregate_module, aggregate_uuid) do
+    {:via, @registry_provider, {@aggregate_registry_name, {aggregate_module, aggregate_uuid}}}
   end
 
   @doc false
   def init(%Aggregate{} = state) do
     # initial aggregate state is populated by loading events from event store
-    GenServer.cast(self(), {:populate_aggregate_state})
+    GenServer.cast(self(), :populate_aggregate_state)
 
     {:ok, state}
   end
@@ -62,28 +66,32 @@ defmodule Commanded.Aggregates.Aggregate do
     (see `Commanded.Aggregates.ExecutionContext` for details).
   - `timeout` - is an integer greater than zero which specifies how many
     milliseconds to wait for a reply, or the atom :infinity to wait indefinitely.
-    The default value is 5000.
+    The default value is five seconds (5,000ms).
 
   Returns `{:ok, aggregate_version}` on success, or `{:error, reason}` on failure.
   """
-  def execute(aggregate_uuid, %ExecutionContext{} = context, timeout \\ 5_000) do
-    GenServer.call(via_tuple(aggregate_uuid), {:execute_command, context}, timeout)
+  def execute(aggregate_module, aggregate_uuid, %ExecutionContext{} = context, timeout \\ 5_000) do
+    GenServer.call(via_tuple(aggregate_module, aggregate_uuid), {:execute_command, context}, timeout)
   end
 
   @doc false
-  def aggregate_state(aggregate_uuid), do: GenServer.call(via_tuple(aggregate_uuid), {:aggregate_state})
+  def aggregate_state(aggregate_module, aggregate_uuid) do
+    GenServer.call(via_tuple(aggregate_module, aggregate_uuid), :aggregate_state)
+  end
 
   @doc false
-  def aggregate_state(aggregate_uuid, timeout), do: GenServer.call(via_tuple(aggregate_uuid), {:aggregate_state}, timeout)
+  def aggregate_state(aggregate_module, aggregate_uuid, timeout) do
+    GenServer.call(via_tuple(aggregate_module, aggregate_uuid), :aggregate_state, timeout)
+  end
 
   @doc false
-  def aggregate_version(aggregate_uuid), do: GenServer.call(via_tuple(aggregate_uuid), {:aggregate_version})
+  def aggregate_version(aggregate_module, aggregate_uuid) do
+    GenServer.call(via_tuple(aggregate_module, aggregate_uuid), :aggregate_version)
+  end
 
   @doc false
-  def handle_cast({:populate_aggregate_state}, %Aggregate{} = state) do
-    state = populate_aggregate_state(state)
-
-    {:noreply, state}
+  def handle_cast(:populate_aggregate_state, %Aggregate{} = state) do
+    {:noreply, populate_aggregate_state(state)}
   end
 
   @doc false
@@ -94,12 +102,12 @@ defmodule Commanded.Aggregates.Aggregate do
   end
 
   @doc false
-  def handle_call({:aggregate_state}, _from, %Aggregate{aggregate_state: aggregate_state} = state) do
+  def handle_call(:aggregate_state, _from, %Aggregate{aggregate_state: aggregate_state} = state) do
     {:reply, aggregate_state, state}
   end
 
   @doc false
-  def handle_call({:aggregate_version}, _from, %Aggregate{aggregate_version: aggregate_version} = state) do
+  def handle_call(:aggregate_version, _from, %Aggregate{aggregate_version: aggregate_version} = state) do
     {:reply, aggregate_version, state}
   end
 
@@ -110,15 +118,17 @@ defmodule Commanded.Aggregates.Aggregate do
 
   # Load any existing events for the aggregate from storage and repopulate the state using those events
   defp populate_aggregate_state(%Aggregate{aggregate_module: aggregate_module} = state) do
-    rebuild_from_events(%Aggregate{state |
+    aggregate = %Aggregate{state |
       aggregate_version: 0,
       aggregate_state: struct(aggregate_module)
-    })
+    }
+
+    rebuild_from_events(aggregate)
   end
 
   # Load events from the event store, in batches, to rebuild the aggregate state
-  defp rebuild_from_events(%Aggregate{aggregate_uuid: aggregate_uuid, aggregate_module: aggregate_module} = state) do
-    case EventStore.stream_forward(aggregate_uuid, 0, @read_event_batch_size) do
+  defp rebuild_from_events(%Aggregate{aggregate_module: aggregate_module} = state) do
+    case EventStore.stream_forward(stream_uuid(state), 0, @read_event_batch_size) do
       {:error, :stream_not_found} ->
         # aggregate does not exist so return empty state
         state
@@ -152,7 +162,7 @@ defmodule Commanded.Aggregates.Aggregate do
 
   defp execute_command(
     %ExecutionContext{handler: handler, function: function, command: command, metadata: metadata},
-    %Aggregate{aggregate_uuid: aggregate_uuid, aggregate_version: expected_version, aggregate_state: aggregate_state, aggregate_module: aggregate_module} = state)
+    %Aggregate{aggregate_module: aggregate_module, aggregate_version: expected_version, aggregate_state: aggregate_state} = state)
   do
     case Kernel.apply(handler, function, [aggregate_state, command]) do
       {:error, _reason} = reply -> {reply, state}
@@ -161,7 +171,7 @@ defmodule Commanded.Aggregates.Aggregate do
 
         updated_state = apply_events(aggregate_module, aggregate_state, pending_events)
 
-        {:ok, stream_version} = persist_events(pending_events, aggregate_uuid, expected_version, metadata)
+        {:ok, stream_version} = persist_events(pending_events, stream_uuid(state), expected_version, metadata)
 
         state = %Aggregate{state |
           aggregate_state: updated_state,
@@ -176,11 +186,15 @@ defmodule Commanded.Aggregates.Aggregate do
     Enum.reduce(events, aggregate_state, &aggregate_module.apply(&2, &1))
   end
 
-  defp persist_events([], _aggregate_uuid, expected_version, _metadata), do: {:ok, expected_version}
-  defp persist_events(pending_events, aggregate_uuid, expected_version, metadata) do
-    correlation_id = UUID.uuid4
+  defp persist_events([], _stream_uuid, expected_version, _metadata), do: {:ok, expected_version}
+  defp persist_events(pending_events, stream_uuid, expected_version, metadata) do
+    correlation_id = UUID.uuid4()
     event_data = Mapper.map_to_event_data(pending_events, correlation_id, nil, metadata)
 
-    EventStore.append_to_stream(aggregate_uuid, expected_version, event_data)
+    EventStore.append_to_stream(stream_uuid, expected_version, event_data)
   end
+
+  # Get the stream indentity to read/append events for the aggregate, with an optional prefix
+  defp stream_uuid(%Aggregate{aggregate_uuid: aggregate_uuid, identity_prefix: nil}), do: aggregate_uuid
+  defp stream_uuid(%Aggregate{aggregate_uuid: aggregate_uuid, identity_prefix: identity_prefix}), do: identity_prefix <> aggregate_uuid
 end

--- a/lib/commanded/aggregates/supervisor.ex
+++ b/lib/commanded/aggregates/supervisor.ex
@@ -15,14 +15,15 @@ defmodule Commanded.Aggregates.Supervisor do
 
   Returns `{:ok, aggregate_uuid}` when a process is sucessfully started, or is already running.
   """
-  def open_aggregate(aggregate_module, aggregate_uuid)
+  def open_aggregate(aggregate_module, aggregate_uuid, identity_prefix \\ nil)
+  def open_aggregate(aggregate_module, aggregate_uuid, identity_prefix)
     when is_integer(aggregate_uuid) or
          is_atom(aggregate_uuid) or
          is_bitstring(aggregate_uuid) do
 
     Logger.debug(fn -> "Locating aggregate process for `#{inspect aggregate_module}` with UUID #{inspect aggregate_uuid}" end)
 
-    case Supervisor.start_child(__MODULE__, [aggregate_module, aggregate_uuid]) do
+    case Supervisor.start_child(__MODULE__, [aggregate_module, aggregate_uuid, identity_prefix]) do
       {:ok, _pid} -> {:ok, aggregate_uuid}
       {:error, {:already_started, _pid}} -> {:ok, aggregate_uuid}
       other -> {:error, other}

--- a/lib/commanded/middleware/extract_aggregate_identity.ex
+++ b/lib/commanded/middleware/extract_aggregate_identity.ex
@@ -24,7 +24,13 @@ defmodule Commanded.Middleware.ExtractAggregateIdentity do
 
   def after_failure(%Pipeline{} = pipeline), do: pipeline
 
-  defp extract_aggregate_uuid(%Pipeline{command: command, identity: identity}) do
+  # extract identity using a user-provider function
+  defp extract_aggregate_uuid(%Pipeline{command: command, identity: identity}) when is_function(identity) do
+    identity.(command)
+  end
+
+  # extract identity using a field in the command
+  defp extract_aggregate_uuid(%Pipeline{command: command, identity: identity}) when is_atom(identity) do
     Map.get(command, identity)
   end
 end

--- a/test/aggregates/aggregate_lifespan_test.exs
+++ b/test/aggregates/aggregate_lifespan_test.exs
@@ -36,7 +36,7 @@ defmodule Commanded.Aggregates.AggregateLifespanTest do
 
       {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(BankAccount, aggregate_uuid)
 
-      pid = apply(@registry_provider, :whereis_name, [{:aggregate_registry, aggregate_uuid}])
+      pid = apply(@registry_provider, :whereis_name, [{:aggregate_registry, {BankAccount, aggregate_uuid}}])
       ref = Process.monitor(pid)
 
       %{aggregate_uuid: aggregate_uuid, ref: ref}

--- a/test/aggregates/event_persistence_test.exs
+++ b/test/aggregates/event_persistence_test.exs
@@ -52,7 +52,7 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    {:ok, 10} = Aggregate.execute(aggregate_uuid, %ExecutionContext{command: %AppendItems{count: 10}, handler: AppendItemsHandler, function: :handle})
+    {:ok, 10} = Aggregate.execute(ExampleAggregate, aggregate_uuid, %ExecutionContext{command: %AppendItems{count: 10}, handler: AppendItemsHandler, function: :handle})
 
     recorded_events = EventStore.stream_forward(aggregate_uuid, 0) |> Enum.to_list()
 
@@ -72,7 +72,7 @@ defmodule Commanded.Entities.EventPersistenceTest do
     metadata = %{"ip_address" => "127.0.0.1"}
     context = %ExecutionContext{command: %AppendItems{count: 10}, metadata: metadata, handler: AppendItemsHandler, function: :handle}
 
-    {:ok, 10} = Aggregate.execute(aggregate_uuid, context)
+    {:ok, 10} = Aggregate.execute(ExampleAggregate, aggregate_uuid, context)
 
     recorded_events = EventStore.stream_forward(aggregate_uuid, 0) |> Enum.to_list()
 
@@ -86,14 +86,14 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    {:ok, 10} = Aggregate.execute(aggregate_uuid, %ExecutionContext{command: %AppendItems{count: 10}, handler: AppendItemsHandler, function: :handle})
+    {:ok, 10} = Aggregate.execute(ExampleAggregate, aggregate_uuid, %ExecutionContext{command: %AppendItems{count: 10}, handler: AppendItemsHandler, function: :handle})
 
-    Commanded.Helpers.Process.shutdown(aggregate_uuid)
+    Commanded.Helpers.Process.shutdown(ExampleAggregate, aggregate_uuid)
 
     {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    assert Aggregate.aggregate_version(aggregate_uuid) == 10
-    assert Aggregate.aggregate_state(aggregate_uuid) == %Commanded.Entities.EventPersistenceTest.ExampleAggregate{
+    assert Aggregate.aggregate_version(ExampleAggregate, aggregate_uuid) == 10
+    assert Aggregate.aggregate_state(ExampleAggregate, aggregate_uuid) == %Commanded.Entities.EventPersistenceTest.ExampleAggregate{
       items: 1..10 |> Enum.to_list(),
       last_index: 10,
     }
@@ -104,16 +104,16 @@ defmodule Commanded.Entities.EventPersistenceTest do
 
     {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    {:ok, 100} = Aggregate.execute(aggregate_uuid, %ExecutionContext{command: %AppendItems{count: 100}, handler: AppendItemsHandler, function: :handle})
-    {:ok, 200} = Aggregate.execute(aggregate_uuid, %ExecutionContext{command: %AppendItems{count: 100}, handler: AppendItemsHandler, function: :handle})
-    {:ok, 201} = Aggregate.execute(aggregate_uuid, %ExecutionContext{command: %AppendItems{count: 1}, handler: AppendItemsHandler, function: :handle})
+    {:ok, 100} = Aggregate.execute(ExampleAggregate, aggregate_uuid, %ExecutionContext{command: %AppendItems{count: 100}, handler: AppendItemsHandler, function: :handle})
+    {:ok, 200} = Aggregate.execute(ExampleAggregate, aggregate_uuid, %ExecutionContext{command: %AppendItems{count: 100}, handler: AppendItemsHandler, function: :handle})
+    {:ok, 201} = Aggregate.execute(ExampleAggregate, aggregate_uuid, %ExecutionContext{command: %AppendItems{count: 1}, handler: AppendItemsHandler, function: :handle})
 
-    Commanded.Helpers.Process.shutdown(aggregate_uuid)
+    Commanded.Helpers.Process.shutdown(ExampleAggregate, aggregate_uuid)
 
     {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(ExampleAggregate, aggregate_uuid)
 
-    assert Aggregate.aggregate_version(aggregate_uuid) == 201
-    assert Aggregate.aggregate_state(aggregate_uuid) == %Commanded.Entities.EventPersistenceTest.ExampleAggregate{
+    assert Aggregate.aggregate_version(ExampleAggregate, aggregate_uuid) == 201
+    assert Aggregate.aggregate_state(ExampleAggregate, aggregate_uuid) == %Commanded.Entities.EventPersistenceTest.ExampleAggregate{
       items: 1..201 |> Enum.to_list,
       last_index: 201,
     }

--- a/test/aggregates/registry_test.exs
+++ b/test/aggregates/registry_test.exs
@@ -3,7 +3,7 @@ defmodule SupervisorTest do
 
   test "should let use integer, atom or string as aggregate_uuid" do
     Enum.each([1, :atom, "string"], fn aggregate_uuid ->
-      {:ok, _aggregate} = Commanded.Aggregates.Supervisor.open_aggregate(Commanded.ExampleDomain.BankAccount, aggregate_uuid)
+      {:ok, ^aggregate_uuid} = Commanded.Aggregates.Supervisor.open_aggregate(Commanded.ExampleDomain.BankAccount, aggregate_uuid)
     end)
   end
 end

--- a/test/helpers/process.ex
+++ b/test/helpers/process.ex
@@ -12,7 +12,7 @@ defmodule Commanded.Helpers.Process do
     Process.exit(pid, :shutdown)
 
     ref = Process.monitor(pid)
-    assert_receive {:DOWN, ^ref, _, _, _}
+    assert_receive {:DOWN, ^ref, _, _, _}, 5_000
   end
 
   def shutdown(name) when is_atom(name) do

--- a/test/helpers/process.ex
+++ b/test/helpers/process.ex
@@ -12,11 +12,18 @@ defmodule Commanded.Helpers.Process do
     Process.exit(pid, :shutdown)
 
     ref = Process.monitor(pid)
-    assert_receive {:DOWN, ^ref, _, _, _}, 5_000
+    assert_receive {:DOWN, ^ref, _, _, _}
   end
 
-  def shutdown(aggregate_uuid) do
-    pid = apply(@registry_provider, :whereis_name, [{:aggregate_registry, aggregate_uuid}])
+  def shutdown(name) when is_atom(name) do
+    case Process.whereis(name) do
+      nil -> :ok
+      pid -> shutdown(pid)
+    end
+  end
+
+  def shutdown(aggregate_module, aggregate_uuid) do
+    pid = apply(@registry_provider, :whereis_name, [{:aggregate_registry, {aggregate_module, aggregate_uuid}}])
     shutdown(pid)
   end
 end


### PR DESCRIPTION
Add support to command router to allow further specification of an aggregate identity and additionally an identity prefix.

1. Allow the aggregate identity prefix to be specified during command registration:

    ```elixir
    defmodule BankRouter do
      use Commanded.Commands.Router

      dispatch [OpenAccount,DepositMoney,WithdrawMoney] 
        to: BankAccount, 
        identity: :account_number,
        identity_prefix: "bank-account-"
    end
    ```

2. Allow a function to be used as the `identity` option; you construct the identity as required from the command being dispatched:

    ```elixir
    defmodule BankRouter do
      use Commanded.Commands.Router

      dispatch [RegisterUser] 
        to: User, 
        identity: fn %{uuid: uuid} -> "user-#{uuid}" end

      dispatch [OpenAccount,DepositMoney,WithdrawMoney] 
        to: BankAccount, 
        identity: &BankRouter.account_identity/1

      def account_identity(%{account_number: account_number}), do: "bank-account-#{account_number}"
    end
    ```

3. Allow an aggregate identity to be specified for all its commands, providing an optional prefix:

    ```elixir
    defmodule BankRouter do
      use Commanded.Commands.Router

      identify BankAccount, 
        by: :account_number, 
        prefix: "bank-account-"

      dispatch [OpenAccount,DepositMoney,WithdrawMoney] to: BankAccount
    end
    ```

Closes #77.