### PR TITLE
Remove unnecessary warning when a process managers stops itself

### DIFF
--- a/lib/commanded/process_managers/process_router.ex
+++ b/lib/commanded/process_managers/process_router.ex
@@ -119,7 +119,9 @@ defmodule Commanded.ProcessManagers.ProcessRouter do
   end
 
   def handle_info({:DOWN, _ref, :process, pid, reason}, %State{process_managers: process_managers} = state) do
-    Logger.warn(fn -> "process manager process down due to: #{inspect reason}" end)
+    if reason != :normal do
+      Logger.warn(fn -> "process manager process down due to: #{inspect reason}" end)
+    end
 
     {:noreply, %State{state | process_managers: remove_process_manager(process_managers, pid)}}
   end


### PR DESCRIPTION
A normal stop is already logged in `handle_event/2` with a debug level.