### PR TITLE
Ignore strong consistency check when command creates no events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: elixir
 
 elixir:
-  - 1.5.1
+  - 1.5.2
 
 otp_release:
-  - 20.0
+  - 20.1

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -38,17 +38,15 @@ defmodule Commanded.Commands.Dispatcher do
       |> before_dispatch(payload)
 
     # don't allow command execution if pipeline has been halted
-    case Pipeline.halted?(pipeline) do
-      true ->
-        pipeline
-        |> Pipeline.respond({:error, :halted})
-        |> after_failure(:halted, payload)
-        |> Pipeline.response()
-
-      false ->
-        pipeline
-        |> execute(payload)
-        |> Pipeline.response()
+    unless Pipeline.halted?(pipeline) do
+      pipeline
+      |> execute(payload)
+      |> Pipeline.response()
+    else
+      pipeline
+      |> Pipeline.respond({:error, :halted})
+      |> after_failure(:halted, payload)
+      |> Pipeline.response()
     end
   end
 

--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -75,9 +75,10 @@ defmodule Commanded.Commands.Dispatcher do
       end
 
     case result do
-      {:ok, aggregate_version} ->
+      {:ok, aggregate_version, event_count} ->
         pipeline
         |> Pipeline.assign(:aggregate_version, aggregate_version)
+        |> Pipeline.assign(:event_count, event_count)
         |> after_dispatch(payload)
         |> respond_with_success(payload, aggregate_version)
 

--- a/lib/commanded/middleware/consistency_guarantee.ex
+++ b/lib/commanded/middleware/consistency_guarantee.ex
@@ -19,6 +19,7 @@ defmodule Commanded.Middleware.ConsistencyGuarantee do
   def before_dispatch(%Pipeline{} = pipeline), do: pipeline
 
   def after_dispatch(%Pipeline{consistency: :eventual} = pipeline), do: pipeline
+  def after_dispatch(%Pipeline{consistency: :strong, assigns: %{event_count: 0}} = pipeline), do: pipeline
   def after_dispatch(%Pipeline{consistency: :strong, assigns: %{aggregate_uuid: aggregate_uuid, aggregate_version: aggregate_version}} = pipeline) do
     case Subscriptions.wait_for(aggregate_uuid, aggregate_version) do
       :ok ->

--- a/lib/commanded/middleware/pipeline.ex
+++ b/lib/commanded/middleware/pipeline.ex
@@ -6,10 +6,12 @@ defmodule Commanded.Middleware.Pipeline do
 
   ## Pipeline fields
 
-    * `assigns` - shared user data as a map
-    * `command` - the command struct being dispatched
-    * `consistency` - the requested dispatch consistency, either `:eventual` (default) or `:strong`
-    * `identity` - the field in the command containing the aggregate's identity
+    * `assigns` - shared user data as a map.
+    * `command` - the command struct being dispatched.
+    * `consistency` - the requested dispatch consistency, either: `:eventual` (default) or `:strong`
+    * `identity` - an atom specifying a field in the command containing the
+                   aggregate's identity or a one-arity function that returns
+                   an identity from the command being dispatched.
     * `halted` - the boolean status on whether the pipeline was halted
     * `response` - set the response to send back to the caller
 

--- a/test/aggregates/execute_command_for_aggregate_test.exs
+++ b/test/aggregates/execute_command_for_aggregate_test.exs
@@ -9,7 +9,7 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
   alias Commanded.Helpers
 
   @registry_provider Application.get_env(:commanded, :registry_provider, Registry)
-
+  
   test "execute command against an aggregate" do
     account_number = UUID.uuid4
 
@@ -18,7 +18,7 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
     command = %OpenAccount{account_number: account_number, initial_balance: 1_000}
     context = %ExecutionContext{command: command, handler: BankAccount, function: :open_account}
 
-    {:ok, 1} = Aggregate.execute(BankAccount, account_number, context)
+    {:ok, 1, 1} = Aggregate.execute(BankAccount, account_number, context)
 
     Helpers.Process.shutdown(BankAccount, account_number)
 
@@ -37,7 +37,7 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
     command = %OpenAccount{account_number: account_number, initial_balance: 1_000}
     context = %ExecutionContext{command: command, handler: OpenAccountHandler, function: :handle}
 
-    {:ok, 1} = Aggregate.execute(BankAccount, account_number, context)
+    {:ok, 1, 1} = Aggregate.execute(BankAccount, account_number, context)
 
     Helpers.Process.shutdown(BankAccount, account_number)
 
@@ -56,7 +56,7 @@ defmodule Commanded.Entities.ExecuteCommandForAggregateTest do
     command = %OpenAccount{account_number: account_number, initial_balance: 1_000}
     context = %ExecutionContext{command: command, handler: OpenAccountHandler, function: :handle}
 
-    {:ok, 1} = Aggregate.execute(BankAccount, account_number, context)
+    {:ok, 1, 1} = Aggregate.execute(BankAccount, account_number, context)
 
     state_before = Aggregate.aggregate_state(BankAccount, account_number)
 


### PR DESCRIPTION
Commands that create no events don't require consistency checks.

Prevent blocking indefinitely when a strongly consistent event handler dispatches a command using `consistency: :strong`.