### PR TITLE
Fail `assert_receive_event` if `event_type` isn't a known module

### DIFF
--- a/lib/commanded/assertions/event_assertions.ex
+++ b/lib/commanded/assertions/event_assertions.ex
@@ -50,6 +50,9 @@ defmodule Commanded.Assertions.EventAssertions do
   Assert that an event of the given event type, matching the predicate, is published. Verify that event using the assertion function.
   """
   def assert_receive_event(event_type, predicate_fn, assertion_fn) do
+    unless Code.ensure_compiled?(event_type) do
+      raise ExUnit.AssertionError, "event_type #{inspect(event_type)} not found"
+    end
     with_subscription(fn subscription ->
       do_assert_receive(subscription, event_type, predicate_fn, assertion_fn)
     end)


### PR DESCRIPTION
`assert_receive_event` waits for an event of a specific type. But it
doesn't recognize if the given event type isn't valid, e.g. because it
hasn't been alias or has a typo. That way a test that should succeed
if the module had been aliased fails.

This change ensures the type is a known one or else raises an
assertion exception which indicates the fact.