### PR TITLE
Let middlewares modify metadata before dispatch

### DIFF
--- a/lib/commanded/commands/dispatcher.ex
+++ b/lib/commanded/commands/dispatcher.ex
@@ -51,12 +51,13 @@ defmodule Commanded.Commands.Dispatcher do
     end
   end
 
-  defp to_pipeline(%Payload{command: command, consistency: consistency, identity: identity, identity_prefix: identity_prefix}) do
+  defp to_pipeline(%Payload{command: command, consistency: consistency, identity: identity, identity_prefix: identity_prefix, metadata: metadata}) do
     %Pipeline{
       command: command,
       consistency: consistency,
       identity: identity,
       identity_prefix: identity_prefix,
+      metadata: metadata
     }
   end
 
@@ -100,8 +101,8 @@ defmodule Commanded.Commands.Dispatcher do
   end
 
   defp to_execution_context(
-    %Pipeline{command: command},
-    %Payload{handler_module: handler_module, handler_function: handler_function, lifespan: lifespan, metadata: metadata})
+    %Pipeline{command: command, metadata: metadata},
+    %Payload{handler_module: handler_module, handler_function: handler_function, lifespan: lifespan})
   do
     %ExecutionContext{
       command: command,
@@ -112,7 +113,7 @@ defmodule Commanded.Commands.Dispatcher do
     }
   end
 
-  defp respond_with_success(%Pipeline{} = pipeline, %Payload{metadata: metadata} = payload, events) do
+  defp respond_with_success(%Pipeline{} = pipeline, payload, events) do
     response =
       case payload do
         %{include_execution_result: true} ->
@@ -122,7 +123,7 @@ defmodule Commanded.Commands.Dispatcher do
               aggregate_uuid: pipeline.assigns.aggregate_uuid,
               aggregate_version: pipeline.assigns.aggregate_version,
               events: events,
-              metadata: metadata,
+              metadata: pipeline.metadata,
             }
           }
         %{include_aggregate_version: true} -> {:ok, pipeline.assigns.aggregate_version}

--- a/lib/commanded/middleware/pipeline.ex
+++ b/lib/commanded/middleware/pipeline.ex
@@ -15,6 +15,7 @@ defmodule Commanded.Middleware.Pipeline do
     * `identity` - An atom specifying a field in the command containing the
        aggregate's identity or a one-arity function that returns
        an identity from the command being dispatched.
+    * `metadata` - the metadata map to be persisted along with the events.
     * `identity_prefix` - An optional prefix to the aggregate's identity.
     * `halted` - Boolean status on whether the pipeline was halted
     * `response` - Set the response to send back to the caller
@@ -27,6 +28,7 @@ defmodule Commanded.Middleware.Pipeline do
     consistency: nil,
     identity: nil,
     identity_prefix: nil,
+    metadata: nil,
     halted: false,
     response: nil,
   ]
@@ -40,6 +42,13 @@ defmodule Commanded.Middleware.Pipeline do
     when is_atom(key)
   do
     %Pipeline{pipeline | assigns: Map.put(assigns, key, value)}
+  end
+
+  @doc """
+  Puts the `key` with value equal to `value` into `metadata` map
+  """
+  def assign_metadata(%Pipeline{metadata: metadata, response: response} = pipeline, key, value) when is_atom(key) do
+    %Pipeline{pipeline | metadata: Map.put(metadata, key, value)}
   end
 
   @doc """


### PR DESCRIPTION
This is useful for middleware like [commanded-audit-middleware](https://github.com/commanded/commanded-audit-middleware/), which would be able to put the command uuid inside metadata automatically.